### PR TITLE
fix: config 중복 내용 수정 및 vercelignore추가

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,2 @@
+output/
+*.d.ts

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,6 @@
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-
     "skipLibCheck": true,
 
     /* Bundler mode */
@@ -29,5 +28,11 @@
       "@assets/*": ["./src/assets/*"]
     }
   },
-  "include": ["src", "**/*.ts", "**/*.tsx", "tailwind.config.js", "fsd"]
+  "include": [
+    "src",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "tailwind.config.js",
+    "src/types/custom.d.ts"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,5 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
-  ],
-  "compilerOptions": {
-    "strict": true
-  },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/types/custom.d.ts"]
+  ]
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

### #️⃣ 이슈 번호

> close #48 

## 📋 작업 내용

- config 내부 중복 코드 제거
- vercel ignore 추가



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Vercel 배포 시 output 디렉터리와 .d.ts 파일이 무시되도록 설정이 추가되었습니다.
	- tsconfig.app.json에서 포함 파일 패턴이 명확하게 지정되고, 불필요한 항목이 제거되었습니다.
	- tsconfig.json이 간소화되어 컴파일러 옵션과 포함 파일 설정이 하위 구성으로 위임되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->