### PR TITLE
feat: 소셜 로그인 구현 및 HTTPS 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# SSL 인증서
+*.crt
+*.key
+cert.crt
+key.key

--- a/src/pages/pages/auth/login/index.tsx
+++ b/src/pages/pages/auth/login/index.tsx
@@ -5,13 +5,12 @@ import { SocialLoginButton } from '@/components/common-ui/SocialLoginButton';
 
 const LoginPage = () => {
   const handleKakaoLogin = () => {
-    // 카카오 로그인 로직 구현
-    console.log('카카오 로그인 시도');
+    window.location.href = 'https://dev.linkrew.com/oauth2/authorization/kakao';
   };
 
   const handleGoogleLogin = () => {
-    // 구글 로그인 로직 구현
-    console.log('구글 로그인 시도');
+    window.location.href =
+      'https://dev.linkrew.com/oauth2/authorization/google';
   };
 
   const textData = [

--- a/src/pages/pages/reissue/page.tsx
+++ b/src/pages/pages/reissue/page.tsx
@@ -1,34 +1,57 @@
-// "use client";
+import { useEffect } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
-// import { useEffect } from "react";
-// import { useRouter } from "next/navigation";
-// import axios from "axios";
+export default function ReissuePage() {
+  console.log('ReissuePage 컴포넌트 렌더링');
+  const navigate = useNavigate();
 
-// export default function ReissuePage() {
-//   const router = useRouter();
+  useEffect(() => {
+    console.log('ReissuePage useEffect 실행');
+    console.log('현재 쿠키:', document.cookie);
 
-//   useEffect(() => {
-//     const fetchAccessToken = async () => {
-//       try {
-//         // Request the access token using the refresh token stored in cookies
-//         const response = await axios.get(
-//           "http://localhost:8080/api/jwt/access-token",
-//           { withCredentials: true }
-//         );
-//         const accessToken = response.data.access_token;
+    const fetchAccessToken = async () => {
+      console.log('액세스 토큰 요청 함수 시작');
+      try {
+        console.log(
+          'API 요청 시작: https://dev.linkrew.com/api/jwt/access-token'
+        );
 
-//         localStorage.setItem("access_token", accessToken);
-//         console.log(response);
-//         router.replace("/personal");
-//       } catch (error) {
-//         console.error("Error fetching access token:", error);
+        const response = await axios.get(
+          'https://dev.linkrew.com/api/jwt/access-token',
+          { withCredentials: true }
+        );
+        console.log('API 응답 받음:', response);
+        console.log('응답 데이터:', response.data);
+        console.log('응답 헤더:', response.headers);
 
-//         // window.location.href = "http://localhost:8080/login";
-//       }
-//     };
+        const accessToken = response.data.access_token;
+        console.log('추출된 액세스 토큰:', accessToken);
 
-//     fetchAccessToken();
-//   }, [router]);
+        localStorage.setItem('access_token', accessToken);
+        console.log('로컬 스토리지에 토큰 저장 완료');
 
-//   return <p>Reissuing access token... Please wait.</p>;
-// }
+        console.log('메인 페이지로 리다이렉트 시작');
+        navigate('/');
+        console.log('리다이렉트 명령 실행됨');
+      } catch (error) {
+        console.error('액세스 토큰 요청 중 오류 발생:', error);
+
+        if (axios.isAxiosError(error)) {
+          console.log('오류 응답 데이터:', error.response?.data);
+          console.log('오류 응답 상태:', error.response?.status);
+          console.log('오류 메시지:', error.message);
+        } else {
+          console.log('알 수 없는 오류 발생', error);
+        }
+      }
+    };
+
+    fetchAccessToken();
+    return () => {
+      console.log('ReissuePage 컴포넌트 언마운트');
+    };
+  }, [navigate]);
+
+  return <p>Reissuing access token... Please wait.</p>;
+}

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -4,6 +4,7 @@ import LoginPage from '@/pages/pages/auth/login';
 import SignupPage from '@/pages/pages/auth/signup';
 import { LandingPage } from '@/pages/pages/landing/ui/LandingPage';
 import PageLayout from '@/components/page-layout/PageLayout';
+import ReissuePage from '@/pages/pages/reissue/page';
 
 const router = createBrowserRouter([
   {
@@ -13,6 +14,7 @@ const router = createBrowserRouter([
       { path: 'login', element: <LoginPage /> },
       { path: 'signup', element: <SignupPage /> },
       { path: 'landing', element: <LandingPage /> },
+      { path: 'reissue', element: <ReissuePage /> },
     ],
   },
 ]);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import fs from 'fs';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -15,4 +16,10 @@ export default defineConfig({
     },
   },
   assetsInclude: ['**/*.webp'],
+  server: {
+    https: {
+      key: fs.readFileSync('./key.key'), // SSL key 파일 경로
+      cert: fs.readFileSync('./cert.crt'), // SSL 인증서 파일 경로
+    },
+  },
 });


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- 구글/카카오 소셜 로그인 버튼 구현
- 리다이렉트 처리를 위한 reissue 페이지 구현
- 인증서 파일을 .gitignore에 추가하여 보안 강화
- 로컬 개발 환경을 위한 HTTPS 설정 추가
- 라우터에 reissue 경로 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
    - 로그인 페이지에서 카카오 및 구글 로그인 버튼 클릭 시 실제 OAuth2 인증 페이지로 리디렉션되도록 개선되었습니다.
    - `/reissue` 경로가 라우터에 추가되어 토큰 재발급 페이지로 접근할 수 있습니다.

- **버그 수정**
    - 토큰 재발급 페이지가 React Router 및 프로덕션 API 엔드포인트를 사용하도록 전면 수정되었으며, 오류 처리와 진단 로그가 강화되었습니다.

- **환경설정**
    - 개발 서버가 HTTPS를 지원하도록 SSL 인증서 파일을 적용하였습니다.
    - SSL 인증서 및 키 파일이 버전 관리에서 제외되도록 `.gitignore`가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->