### PR TITLE
feat: 인증 상태에 따른 라우터 리다이렉트 기능 구현

### DIFF
--- a/src/components/common-ui/ProtectedRoute.tsx
+++ b/src/components/common-ui/ProtectedRoute.tsx
@@ -1,0 +1,20 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
+
+export const ProtectedRoute = () => {
+  const { isAuthenticated, isLoading } = useAuth();
+  const location = useLocation();
+
+  // 인증 상태 로딩 중일 때는 로딩 표시
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
+
+  // 인증되지 않은 경우 로그인 페이지로 리다이렉트 (현재 경로를 state로 저장)
+  if (!isAuthenticated) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  // 인증된 경우 원래 라우트 렌더링
+  return <Outlet />;
+};

--- a/src/components/common-ui/RedirectIfAuthenticated.tsx
+++ b/src/components/common-ui/RedirectIfAuthenticated.tsx
@@ -1,0 +1,19 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
+
+export const RedirectIfAuthenticated = () => {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  // 인증 상태 로딩 중일 때는 로딩 표시
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
+
+  // 이미 인증된 사용자는 메인 페이지로 리다이렉트
+  if (isAuthenticated) {
+    return <Navigate to="/" replace />;
+  }
+
+  // 인증되지 않은 경우 원래 라우트 렌더링 (로그인/회원가입 페이지)
+  return <Outlet />;
+};

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+
+export function useAuth() {
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    // 페이지 로드 시 로컬 스토리지에서 토큰 확인
+    const checkAuth = () => {
+      const token = localStorage.getItem('access_token');
+      setIsAuthenticated(!!token);
+      setIsLoading(false);
+    };
+
+    checkAuth();
+  }, []);
+
+  // 로그아웃 함수
+  const logout = () => {
+    localStorage.removeItem('access_token');
+    setIsAuthenticated(false);
+  };
+
+  return { isAuthenticated, isLoading, logout };
+}

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -5,14 +5,29 @@ import SignupPage from '@/pages/pages/auth/signup';
 import { LandingPage } from '@/pages/pages/landing/ui/LandingPage';
 import PageLayout from '@/components/page-layout/PageLayout';
 import ReissuePage from '@/pages/pages/reissue/page';
+import { ProtectedRoute } from '@/components/common-ui/ProtectedRoute';
+import { RedirectIfAuthenticated } from '@/components/common-ui/RedirectIfAuthenticated';
 
 const router = createBrowserRouter([
   {
     element: <Layout />,
     children: [
-      { path: '/', element: <PageLayout /> },
-      { path: 'login', element: <LoginPage /> },
-      { path: 'signup', element: <SignupPage /> },
+      // 인증이 필요한 라우트들
+      {
+        element: <ProtectedRoute />,
+        children: [{ path: '/', element: <PageLayout /> }],
+      },
+
+      // 인증된 사용자는 접근할 필요 없는 라우트들
+      {
+        element: <RedirectIfAuthenticated />,
+        children: [
+          { path: 'login', element: <LoginPage /> },
+          { path: 'signup', element: <SignupPage /> },
+        ],
+      },
+
+      // 항상 접근 가능한 라우트들
       { path: 'landing', element: <LandingPage /> },
       { path: 'reissue', element: <ReissuePage /> },
     ],


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- useAuth 훅 생성하여 사용자 인증 상태 관리 기능 추가
- ProtectedRoute 컴포넌트 구현하여 인증되지 않은 사용자의 보호된 페이지 접근 제한
- RedirectIfAuthenticated 컴포넌트 구현하여 인증된 사용자의 로그인/회원가입 페이지 접근 제한
- Router.tsx 파일 수정하여 라우트 구조 개선 및 인증 기반 리다이렉트 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - 인증 상태에 따라 접근이 제한되는 보호된 라우트 기능이 추가되었습니다.
    - 로그인/회원가입 페이지에 인증된 사용자가 접근 시 자동으로 메인 페이지로 리디렉션됩니다.
    - 인증 상태 확인 및 로그아웃 기능을 제공하는 인증 관리 기능이 도입되었습니다.

- **Refactor**
    - 라우팅 구조가 인증 상태에 따라 접근 가능 여부를 명확히 구분하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->