### PR TITLE
fix: 소셜 로그인 리다이렉트 및 CORS 이슈 해결

### DIFF
--- a/src/components/page-layout/PageLayout.tsx
+++ b/src/components/page-layout/PageLayout.tsx
@@ -20,7 +20,8 @@ export default function PageLayout() {
   const [description, setDescription] = useState('');
   const [isBookmark, setIsBookmark] = useState(false);
   const [view, setView] = useState<'grid' | 'list'>('grid');
-  const { showSidebar } = useOutletContext<ContextType>();
+  const context = useOutletContext<ContextType | null>();
+  const showSidebar = context?.showSidebar ?? true; // 기본값으로 true 사용
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;

--- a/src/pages/pages/auth/login/index.tsx
+++ b/src/pages/pages/auth/login/index.tsx
@@ -5,12 +5,11 @@ import { SocialLoginButton } from '@/components/common-ui/SocialLoginButton';
 
 const LoginPage = () => {
   const handleKakaoLogin = () => {
-    window.location.href = 'https://dev.linkrew.com/oauth2/authorization/kakao';
+    window.location.href = 'http://localhost:8080/oauth2/authorization/kakao';
   };
 
   const handleGoogleLogin = () => {
-    window.location.href =
-      'https://dev.linkrew.com/oauth2/authorization/google';
+    window.location.href = 'http://localhost:8080/oauth2/authorization/google';
   };
 
   const textData = [

--- a/src/pages/pages/reissue/page.tsx
+++ b/src/pages/pages/reissue/page.tsx
@@ -13,14 +13,11 @@ export default function ReissuePage() {
     const fetchAccessToken = async () => {
       console.log('액세스 토큰 요청 함수 시작');
       try {
-        console.log(
-          'API 요청 시작: https://dev.linkrew.com/api/jwt/access-token'
-        );
+        console.log('API 요청 시작: /api/jwt/access-token');
 
-        const response = await axios.get(
-          'https://dev.linkrew.com/api/jwt/access-token',
-          { withCredentials: true }
-        );
+        const response = await axios.get('/api/jwt/access-token', {
+          withCredentials: true,
+        });
         console.log('API 응답 받음:', response);
         console.log('응답 데이터:', response.data);
         console.log('응답 헤더:', response.headers);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,15 @@ export default defineConfig({
     },
   },
   assetsInclude: ['**/*.webp'],
-  server: {},
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
   optimizeDeps: {
     exclude: ['@emotion/react', '@emotion/styled', '@mui/material'],
   },


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- 소셜 로그인 URL을 로컬 서버 주소로 변경
- Vite 프록시 설정을 통해 CORS 이슈 해결
- ReissuePage에서 액세스 토큰 요청 URL 상대 경로로 변경
- PageLayout 컴포넌트에 useOutletContext 기본값 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 사이드바 표시 여부를 안전하게 처리하여, 컨텍스트가 없거나 값이 정의되지 않은 경우에도 기본값(true)로 동작하도록 개선했습니다.

- **환경 설정**
  - 로그인 페이지의 소셜 로그인(OAuth2) 리다이렉트 URL을 개발 서버에서 로컬 서버로 변경했습니다.
  - 액세스 토큰 재발급 요청 시 API 호출 경로를 상대 경로로 변경했습니다.
  - 개발 환경에서 API 요청이 로컬 백엔드 서버로 프록시되도록 설정을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->