### PR TITLE
feat: 공유 페이지 멤버, 대쉬보드 조회 및 삭제

### DIFF
--- a/src/apis/folder-apis/createFolder.ts
+++ b/src/apis/folder-apis/createFolder.ts
@@ -3,7 +3,7 @@ import { CreateFolderData } from '@/types/folders';
 
 export async function createFolder(data: CreateFolderData) {
   try {
-    const response = await axiosInstance.post('/api/folders', data);
+    const response = await axiosInstance.post('/api/directories', data);
     return response.data;
   } catch (error) {
     console.error('Error creating folder:', error);

--- a/src/apis/page-apis/deleteSharedPage.ts
+++ b/src/apis/page-apis/deleteSharedPage.ts
@@ -1,0 +1,14 @@
+import { DeleteSharedPageData } from '@/types/pages';
+import { axiosInstance } from '../axiosInstance';
+
+export async function deleteSharedPage(data: DeleteSharedPageData) {
+  try {
+    const response = await axiosInstance.delete('/api/page', {
+      data,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error deleting shared page:', error);
+    throw error;
+  }
+}

--- a/src/apis/page-apis/fetchSharedPageDashboard.ts
+++ b/src/apis/page-apis/fetchSharedPageDashboard.ts
@@ -1,0 +1,17 @@
+import { SelectedPageData } from '@/types/pages';
+import { axiosInstance } from '../axiosInstance';
+
+export async function fetchSharedPageDashboard(data: SelectedPageData) {
+  try {
+    const response = await axiosInstance.get('/api/page/dashboard', {
+      params: {
+        pageId: data.pageId,
+        commandType: data.commandType,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching shared page dashboard:', error);
+    throw error;
+  }
+}

--- a/src/apis/page-apis/fetchSharedPageMember.ts
+++ b/src/apis/page-apis/fetchSharedPageMember.ts
@@ -1,0 +1,17 @@
+import { axiosInstance } from '../axiosInstance';
+import { SelectedPageData } from '@/types/pages';
+
+export async function fetchSharedPageMember(data: SelectedPageData) {
+  try {
+    const response = await axiosInstance.get('/api/page/members', {
+      params: {
+        pageId: data.pageId,
+        commandType: data.commandType,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching shared page member:', error);
+    throw error;
+  }
+}

--- a/src/components/header/UserActions.tsx
+++ b/src/components/header/UserActions.tsx
@@ -74,7 +74,6 @@ export function UserActions() {
           // onToggleDarkMode={handleToggleDarkMode}
           setIsOpen={() => setIsMenuOpen(!isMenuOpen)}
           onWithDrawPage={() => console.log('탈퇴')}
-          onDeletePage={() => console.log('삭제')}
           onContact={() => console.log('문의')}
         />
       )}

--- a/src/components/modal/folder/AddFolderModal.tsx
+++ b/src/components/modal/folder/AddFolderModal.tsx
@@ -49,47 +49,13 @@ export default function AddFolderModal({
         pageId,
         commandType,
       },
-      folderName,
+      directoryName: folderName,
       parentFolderId,
       folderDescription,
     });
   };
 
   const inputClass = 'w-full';
-
-  useEffect(() => {
-    const updateFolder = async () => {
-      try {
-        const res = await fetch('http://localhost:8080/api/folders', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            baseRequest: {
-              pageId: 1,
-              commandType: 'CREATE',
-            },
-            folderName: 'B2',
-            parentFolderId: 1,
-            folderDescription: 'favorite directory4',
-          }),
-        });
-
-        if (!res.ok) {
-          const errData = await res.json();
-          console.error('서버 오류:', errData);
-        } else {
-          const data = await res.json();
-          console.log('업데이트 성공:', data);
-        }
-      } catch (error) {
-        console.error('요청 실패:', error);
-      }
-    };
-
-    updateFolder(); // ✅ 내부에서 실행
-  }, []);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>

--- a/src/components/modal/folder/AddFolderModal.tsx
+++ b/src/components/modal/folder/AddFolderModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Input } from '@/components/common-ui/Input';
 import Modal from '@/components/common-ui/Modal';
 import FolderItemIcon from '@/assets/common-ui-assets/FolderItemIcon.svg?react';
@@ -17,7 +17,7 @@ export default function AddFolderModal({
   onClose,
   pageId = 1,
   parentFolderId = 1,
-  commandType = 'EDIT',
+  commandType = 'CREATE',
 }: AddFolderModalProps) {
   const [folderName, setFolderName] = useState('');
   const [folderDescription, setFolderDescription] = useState('');
@@ -56,6 +56,40 @@ export default function AddFolderModal({
   };
 
   const inputClass = 'w-full';
+
+  useEffect(() => {
+    const updateFolder = async () => {
+      try {
+        const res = await fetch('http://localhost:8080/api/folders', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            baseRequest: {
+              pageId: 1,
+              commandType: 'CREATE',
+            },
+            folderName: 'B2',
+            parentFolderId: 1,
+            folderDescription: 'favorite directory4',
+          }),
+        });
+
+        if (!res.ok) {
+          const errData = await res.json();
+          console.error('서버 오류:', errData);
+        } else {
+          const data = await res.json();
+          console.log('업데이트 성공:', data);
+        }
+      } catch (error) {
+        console.error('요청 실패:', error);
+      }
+    };
+
+    updateFolder(); // ✅ 내부에서 실행
+  }, []);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>

--- a/src/components/modal/page/ModalMenu.tsx
+++ b/src/components/modal/page/ModalMenu.tsx
@@ -1,37 +1,65 @@
 import Consult from '@/assets/common-ui-assets/Consult.svg?react';
 import Withdraw from '@/assets/common-ui-assets/Withdraw.svg?react';
 import Deleted from '@/assets/common-ui-assets/Deleted.svg?react';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useClickOutside } from '@/hooks/useClickOutside';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useDeleteSharedPage } from '@/hooks/mutations/useDeleteSharedPage';
+import { usePageStore } from '@/stores/pageStore';
 // import DarkMode from '@/assets/common-ui-assets/DarkMode.svg?react';
 // import ToggleButton from './ToggleButton';
 
-interface DropDownProps {
+interface ModalMenuProps {
   isHost: boolean;
   // isDarkMode?: boolean;
   // onToggleDarkMode?: () => void;
   onWithDrawPage: () => void;
-  onDeletePage: () => void;
   onContact: () => void;
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function DropDownMenu({
+export default function ModalMenu({
   // isDarkMode = false,
   // onToggleDarkMode,
   isHost,
   onWithDrawPage,
-  onDeletePage,
   onContact,
   setIsOpen,
-}: DropDownProps) {
+}: ModalMenuProps) {
   const modalRef = useRef<HTMLDivElement>(null);
 
+  const navigate = useNavigate();
   useClickOutside(modalRef, setIsOpen);
 
   const location = useLocation();
   const isShared = location.pathname.includes('shared');
+
+  const { pageId: id, commandType: type } = usePageStore();
+
+  useEffect(() => {
+    console.log(id, type);
+  }, [id, type]);
+
+  const deleteSharedPageMutation = useDeleteSharedPage({
+    onSuccess: () => {
+      console.log('공유 페이지 삭제 성공');
+      setIsOpen(false);
+    },
+    onError: () => {
+      console.log('공유 페이지 삭제 실패');
+    },
+  });
+
+  const handleDeleteSharedPage = () => {
+    deleteSharedPageMutation.mutate({
+      baseRequest: {
+        pageId: id,
+        commandType: type,
+      },
+    });
+    navigate('/');
+    console.log('페이지 번호:', id, '삭제 완료');
+  };
 
   return (
     <div
@@ -69,7 +97,7 @@ export default function DropDownMenu({
             </button>
             {isHost && (
               <button
-                onClick={onDeletePage}
+                onClick={handleDeleteSharedPage}
                 className="text-status-danger hover:bg-gray-10 active:bg-gray-5 flex cursor-pointer items-center gap-[10px] rounded-lg px-2 py-[11px] text-[14px] font-[600]"
               >
                 <Deleted /> <span className="text-[14px]">페이지 삭제하기</span>

--- a/src/components/modal/page/ModalMenu.tsx
+++ b/src/components/modal/page/ModalMenu.tsx
@@ -3,6 +3,7 @@ import Withdraw from '@/assets/common-ui-assets/Withdraw.svg?react';
 import Deleted from '@/assets/common-ui-assets/Deleted.svg?react';
 import { useRef } from 'react';
 import { useClickOutside } from '@/hooks/useClickOutside';
+import { useLocation } from 'react-router-dom';
 // import DarkMode from '@/assets/common-ui-assets/DarkMode.svg?react';
 // import ToggleButton from './ToggleButton';
 
@@ -29,6 +30,9 @@ export default function DropDownMenu({
 
   useClickOutside(modalRef, setIsOpen);
 
+  const location = useLocation();
+  const isShared = location.pathname.includes('shared');
+
   return (
     <div
       className="border-gray-30 bg-gray-0 absolute top-14 right-6 z-1 inline-flex w-[198px] flex-col justify-center rounded-[10px] border p-[8px] font-[600] shadow-lg"
@@ -53,23 +57,27 @@ export default function DropDownMenu({
         </div> */}
         <div className="flex"></div>
       </div>
-      <div className="border-gray-40 m-[8px] w-[166px] border" />
-      <div className="flex flex-col">
-        <button
-          onClick={onWithDrawPage}
-          className="text-status-danger hover:bg-gray-10 active:bg-gray-5 flex cursor-pointer items-center gap-[10px] rounded-lg px-2 py-[11px] text-[14px] font-[600]"
-        >
-          <Withdraw /> <span className="text-[14px]">공유 페이지 탈퇴</span>
-        </button>
-        {isHost && (
-          <button
-            onClick={onDeletePage}
-            className="text-status-danger hover:bg-gray-10 active:bg-gray-5 flex cursor-pointer items-center gap-[10px] rounded-lg px-2 py-[11px] text-[14px] font-[600]"
-          >
-            <Deleted /> <span className="text-[14px]">페이지 삭제하기</span>
-          </button>
-        )}
-      </div>
+      {isShared && (
+        <>
+          <div className="border-gray-40 m-[8px] w-[166px] border" />
+          <div className="flex flex-col">
+            <button
+              onClick={onWithDrawPage}
+              className="text-status-danger hover:bg-gray-10 active:bg-gray-5 flex cursor-pointer items-center gap-[10px] rounded-lg px-2 py-[11px] text-[14px] font-[600]"
+            >
+              <Withdraw /> <span className="text-[14px]">공유 페이지 탈퇴</span>
+            </button>
+            {isHost && (
+              <button
+                onClick={onDeletePage}
+                className="text-status-danger hover:bg-gray-10 active:bg-gray-5 flex cursor-pointer items-center gap-[10px] rounded-lg px-2 py-[11px] text-[14px] font-[600]"
+              >
+                <Deleted /> <span className="text-[14px]">페이지 삭제하기</span>
+              </button>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/page-layout/PageContentSection.tsx
+++ b/src/components/page-layout/PageContentSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import FolderItem from './FolderItem';
 import LinkItem from './LinkItem';
 import { ContextMenu } from '../common-ui/ContextMenu';
@@ -6,6 +6,7 @@ import { PageContentSectionProps } from '@/types/pageItems';
 import { useLocation, useParams } from 'react-router-dom';
 import { useFetchSelectedPage } from '@/hooks/queries/useFetchSelectedPage';
 import useFetchFavorite from '@/hooks/queries/useFetchFavorite';
+import { usePageStore } from '@/stores/pageStore';
 
 export default function PageContentSection({ view }: PageContentSectionProps) {
   const [isBookmark, setIsBookmark] = useState(false);
@@ -41,6 +42,13 @@ export default function PageContentSection({ view }: PageContentSectionProps) {
   const data = isBookmarks ? favoriteQuery.favorite : selectedPageQuery.data;
 
   console.log(data);
+
+  // 클릭해서 들어간 페이지 정보 저장
+  const { setPageInfo } = usePageStore();
+
+  useEffect(() => {
+    setPageInfo(resolvedPageId, 'VIEW');
+  }, [resolvedPageId]);
 
   return (
     <div

--- a/src/components/page-layout/PageContentSection.tsx
+++ b/src/components/page-layout/PageContentSection.tsx
@@ -7,6 +7,7 @@ import { useLocation, useParams } from 'react-router-dom';
 import { useFetchSelectedPage } from '@/hooks/queries/useFetchSelectedPage';
 import useFetchFavorite from '@/hooks/queries/useFetchFavorite';
 import { usePageStore } from '@/stores/pageStore';
+import useFetchSharedPageDashboard from '@/hooks/queries/useFetchSharedPageDashboard';
 
 export default function PageContentSection({ view }: PageContentSectionProps) {
   const [isBookmark, setIsBookmark] = useState(false);
@@ -14,11 +15,6 @@ export default function PageContentSection({ view }: PageContentSectionProps) {
     x: number;
     y: number;
   } | null>(null);
-
-  const handleContextMenu = (e: React.MouseEvent) => {
-    e.preventDefault();
-    setContextMenu({ x: e.clientX, y: e.clientY });
-  };
 
   //만약 path param이 없다면 1로 간주하고, 있다면 그대로 꺼내와서 사용.
   const { pageId } = useParams();
@@ -30,7 +26,14 @@ export default function PageContentSection({ view }: PageContentSectionProps) {
     resolvedPageId = parseInt(pageId);
   }
 
-  // 분기: bookmarks면 useFetchFavorite, 아니면 useFetchSelectedPage
+  // 클릭해서 들어간 페이지 정보 전역 변수로사 저장
+  const { setPageInfo } = usePageStore();
+
+  useEffect(() => {
+    setPageInfo(resolvedPageId, 'VIEW');
+  }, [resolvedPageId, setPageInfo]);
+
+  // 분기처리: bookmarks면 useFetchFavorite, 아니면 useFetchSelectedPage
   const favoriteQuery = useFetchFavorite();
   const selectedPageQuery = useFetchSelectedPage({
     pageId: resolvedPageId,
@@ -43,12 +46,19 @@ export default function PageContentSection({ view }: PageContentSectionProps) {
 
   console.log(data);
 
-  // 클릭해서 들어간 페이지 정보 저장
-  const { setPageInfo } = usePageStore();
+  //TODO: 해당 값을 통해서 현재 참여한 유저정보 리스팅
+  const sharedPageDashboardQuery = useFetchSharedPageDashboard({
+    pageId: resolvedPageId,
+    commandType: 'VIEW',
+    enabled: isBookmarks,
+  });
 
-  useEffect(() => {
-    setPageInfo(resolvedPageId, 'VIEW');
-  }, [resolvedPageId]);
+  console.log(sharedPageDashboardQuery.data);
+
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setContextMenu({ x: e.clientX, y: e.clientY });
+  };
 
   return (
     <div

--- a/src/components/page-layout/PageContentSection.tsx
+++ b/src/components/page-layout/PageContentSection.tsx
@@ -8,6 +8,7 @@ import { useFetchSelectedPage } from '@/hooks/queries/useFetchSelectedPage';
 import useFetchFavorite from '@/hooks/queries/useFetchFavorite';
 import { usePageStore } from '@/stores/pageStore';
 import useFetchSharedPageDashboard from '@/hooks/queries/useFetchSharedPageDashboard';
+import useFetchSharedPageMember from '@/hooks/queries/useFetchSharedPageMember';
 
 export default function PageContentSection({ view }: PageContentSectionProps) {
   const [isBookmark, setIsBookmark] = useState(false);
@@ -46,14 +47,21 @@ export default function PageContentSection({ view }: PageContentSectionProps) {
 
   console.log(data);
 
-  //TODO: 해당 값을 통해서 현재 참여한 유저정보 리스팅
+  //TODO: 해당 값을 통해서 현재 공유페이지의 정보 리스팅팅
   const sharedPageDashboardQuery = useFetchSharedPageDashboard({
     pageId: resolvedPageId,
     commandType: 'VIEW',
     enabled: isBookmarks,
   });
 
-  console.log(sharedPageDashboardQuery.data);
+  const sharedPageMemberQuery = useFetchSharedPageMember({
+    pageId: resolvedPageId,
+    commandType: 'VIEW',
+    enabled: isBookmarks,
+  });
+
+  console.log('페이지 대쉬보드 정보', sharedPageDashboardQuery.data);
+  console.log('페이지 멤버 정보', sharedPageMemberQuery.data);
 
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();

--- a/src/hooks/mutations/useDeleteSharedPage.ts
+++ b/src/hooks/mutations/useDeleteSharedPage.ts
@@ -3,16 +3,16 @@ import {
   UseMutationOptions,
   useQueryClient,
 } from '@tanstack/react-query';
-import { createSharedPage } from '@/apis/page-apis/createSharedPage';
-import { CreateSharedPageData } from '@/types/pages';
+import { deleteSharedPage } from '@/apis/page-apis/deleteSharedPage';
+import { DeleteSharedPageData } from '@/types/pages';
 
-export function useCreateSharedPage(
-  options?: UseMutationOptions<any, unknown, CreateSharedPageData>
+export function useDeleteSharedPage(
+  options?: UseMutationOptions<any, unknown, DeleteSharedPageData>
 ) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: createSharedPage,
+    mutationFn: deleteSharedPage,
     onSuccess: (data, variables, context) => {
       queryClient.refetchQueries({ queryKey: ['joinedPage'] });
       options?.onSuccess?.(data, variables, context);

--- a/src/hooks/queries/useFetchJoinedPage.ts
+++ b/src/hooks/queries/useFetchJoinedPage.ts
@@ -6,6 +6,7 @@ export default function useFetchJoinedPage() {
     queryKey: ['joinedPage'],
     queryFn: fetchJoinedPage,
     select: (response) => response.data,
+    staleTime: 1000 * 60,
   });
 
   return { joinedPage: data, ...rest };

--- a/src/hooks/queries/useFetchSharedPageDashboard.ts
+++ b/src/hooks/queries/useFetchSharedPageDashboard.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchSharedPageDashboard } from '@/apis/page-apis/fetchSharedPageDashboard';
+import { SelectedPageData } from '@/types/pages';
+
+export default function useFetchSharedPageDashboard(
+  data: SelectedPageData & { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: ['sharedPageDashboard', data],
+    queryFn: () => fetchSharedPageDashboard(data),
+    enabled: !!data.pageId && !!data.commandType,
+  });
+}

--- a/src/hooks/queries/useFetchSharedPageMember.ts
+++ b/src/hooks/queries/useFetchSharedPageMember.ts
@@ -1,0 +1,13 @@
+import { SelectedPageData } from '@/types/pages';
+import { useQuery } from '@tanstack/react-query';
+import { fetchSharedPageMember } from '@/apis/page-apis/fetchSharedPageMember';
+
+export default function useFetchSharedPageMember(
+  data: SelectedPageData & { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: ['sharedPageMember', data],
+    queryFn: () => fetchSharedPageMember(data),
+    enabled: !!data.pageId && !!data.commandType && !!data.enabled,
+  });
+}

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -4,6 +4,7 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
+      gcTime: 1000 * 60 * 5,
       staleTime: 1000 * 60 * 5,
     },
   },

--- a/src/stores/pageStore.ts
+++ b/src/stores/pageStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+
+interface PageStoreState {
+  pageId: number;
+  commandType: string;
+  setPageInfo: (pageId: number, commandType: string) => void;
+}
+
+export const usePageStore = create<PageStoreState>((set) => ({
+  pageId: 1,
+  commandType: 'VIEW',
+  setPageInfo: (pageId: number, commandType: string) =>
+    set({ pageId, commandType }),
+}));

--- a/src/types/folders.ts
+++ b/src/types/folders.ts
@@ -3,7 +3,7 @@ export type CreateFolderData = {
     pageId: number;
     commandType: string;
   };
-  folderName: string;
+  directoryName: string;
   parentFolderId: number;
   folderDescription: string;
 };

--- a/src/types/pages.ts
+++ b/src/types/pages.ts
@@ -16,3 +16,10 @@ export interface SelectedPageData {
   pageId: number;
   commandType: string;
 }
+
+export interface DeleteSharedPageData {
+  baseRequest: {
+    pageId: number;
+    commandType: string;
+  };
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

### #️⃣ 이슈 번호

> close #85 

## 📋 작업 내용

- 선택한 페이지 정보(id, commandtype)를 zustand로 관리 (컴포넌트가 서로 부모-자식관계가 아니며, pageId와 commandType의 경우 타 api호출 시 여러 컴포넌트에서 사용하기에 선택)
- 공유페이지 삭제 api 호출 (ModalMenu.tsx에서 관리)
- 공유 페이지 대쉬보드 정보 api 호출 (이후 사용 예정)
- 공유페이지 참여 멤버 api 호출 (이후 사용 예정)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 공유 페이지 대시보드 및 멤버 정보 조회 기능이 추가되었습니다.
  - 공유 페이지 삭제 기능이 추가되었습니다.
  - 페이지 관련 상태 관리 기능이 도입되었습니다.

- **개선 사항**
  - 폴더 생성 시 이름 필드가 변경되었습니다.
  - 폴더 생성 시 기본 명령 타입이 'CREATE'로 변경되었습니다.
  - 공유 페이지 관련 데이터의 캐싱 및 쿼리 유지 시간이 조정되었습니다.

- **UI 변경**
  - 페이지 삭제 및 탈퇴 버튼이 공유 페이지에서만 조건부로 표시됩니다.
  - 삭제 버튼 동작이 내부적으로 개선되었습니다.

- **버그 수정**
  - 중복 옵션 전달 및 불필요한 props가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->