### PR TITLE
feat: 링크 crud 기능 구현 및 관련 ui 연동

### DIFF
--- a/src/apis/link-apis/createLink.ts
+++ b/src/apis/link-apis/createLink.ts
@@ -4,7 +4,6 @@ import { axiosInstance } from '../axiosInstance';
 export async function createLink(data: CreateLinkData) {
   try {
     const response = await axiosInstance.post('/api/links', data);
-    console.log('생성response:', response);
     return response.data;
   } catch (error) {
     console.log('Error creating link', error);

--- a/src/apis/link-apis/createLink.ts
+++ b/src/apis/link-apis/createLink.ts
@@ -1,7 +1,9 @@
-import { CreateLinkData } from '@/types/links';
+import { CreateLinkData, CreateLinkResponse } from '@/types/links';
 import { axiosInstance } from '../axiosInstance';
 
-export async function createLink(data: CreateLinkData) {
+export async function createLink(
+  data: CreateLinkData
+): Promise<CreateLinkResponse> {
   try {
     const response = await axiosInstance.post('/api/links', data);
     return response.data;

--- a/src/apis/link-apis/deleteLink.ts
+++ b/src/apis/link-apis/deleteLink.ts
@@ -1,0 +1,12 @@
+import { DeleteLinkData } from '@/types/links';
+import { axiosInstance } from '../axiosInstance';
+
+export async function deleteLink(data: DeleteLinkData) {
+  try {
+    const response = await axiosInstance.delete('/api/links', { data });
+    return response.data;
+  } catch (error) {
+    console.error('삭제 실패:', error);
+    throw error;
+  }
+}

--- a/src/apis/link-apis/deleteLink.ts
+++ b/src/apis/link-apis/deleteLink.ts
@@ -1,7 +1,9 @@
-import { DeleteLinkData } from '@/types/links';
+import { DeleteLinkData, DeleteLinkResponse } from '@/types/links';
 import { axiosInstance } from '../axiosInstance';
 
-export async function deleteLink(data: DeleteLinkData) {
+export async function deleteLink(
+  data: DeleteLinkData
+): Promise<DeleteLinkResponse> {
   try {
     const response = await axiosInstance.delete('/api/links', { data });
     return response.data;

--- a/src/apis/link-apis/updateLink.ts
+++ b/src/apis/link-apis/updateLink.ts
@@ -1,0 +1,14 @@
+import { UpdateLinkData, UpdateLinkResponse } from '@/types/links';
+import { axiosInstance } from '../axiosInstance';
+
+export async function updateLink(
+  data: UpdateLinkData
+): Promise<UpdateLinkResponse> {
+  try {
+    const response = await axiosInstance.put('/api/links', data);
+    return response.data;
+  } catch (error: unknown) {
+    console.error('updateLink API 에러:', error);
+    throw error;
+  }
+}

--- a/src/components/common-ui/DropDownInline.tsx
+++ b/src/components/common-ui/DropDownInline.tsx
@@ -3,6 +3,9 @@ import Transfer from '@/assets/common-ui-assets/Transfer.svg?react';
 import Copy from '@/assets/common-ui-assets/Copy.svg?react';
 import Delete from '@/assets/common-ui-assets/Delete.svg?react';
 import { useClickOutside } from '@/hooks/useClickOutside';
+import { useLinkActionStore } from '@/stores/linkActionStore';
+import { useUpdateLink } from '@/hooks/mutations/useUpdateLink';
+import { usePageStore } from '@/stores/pageStore';
 
 type DropDownInlineProps = {
   id: string;
@@ -36,6 +39,11 @@ const DropDownInline = ({
   const [title, setTitle] = useState(initialTitle);
   const [link, setLink] = useState(initialLink);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const deleteLink = useLinkActionStore((state) => state.deleteLink);
+  const isModified = title !== initialTitle || link !== initialLink;
+  const { mutate } = useUpdateLink();
+
+  const pageId = usePageStore((state) => state.pageId);
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -102,6 +110,25 @@ const DropDownInline = ({
               className="text-gray-60 cursor-pointer resize-none p-[12px] text-[13px] font-[400] outline-none"
             />
           </div>
+          {isModified && (
+            <button
+              onClick={() => {
+                mutate({
+                  baseRequest: {
+                    pageId,
+                    commandType: 'EDIT',
+                  },
+                  linkId: Number(id),
+                  linkName: title,
+                  linkUrl: link,
+                });
+                setIsDropDownInline(false);
+              }}
+              className="text-primary-60 flex cursor-pointer gap-[10px] p-[12px]"
+            >
+              수정 완료
+            </button>
+          )}
           <button
             onClick={() => onShare?.(id)}
             className="flex cursor-pointer items-center gap-[10px] p-[12px]"
@@ -109,7 +136,7 @@ const DropDownInline = ({
             <Transfer width={18} height={18} /> 전송하기
           </button>
           <button
-            onClick={() => onDelete?.(id)}
+            onClick={() => deleteLink(id)}
             className="text-status-danger flex cursor-pointer items-center gap-[10px] p-[12px]"
           >
             <Delete width={18} height={18} /> 삭제하기

--- a/src/components/common-ui/DropDownInline.tsx
+++ b/src/components/common-ui/DropDownInline.tsx
@@ -113,16 +113,26 @@ const DropDownInline = ({
           {isModified && (
             <button
               onClick={() => {
-                mutate({
-                  baseRequest: {
-                    pageId,
-                    commandType: 'EDIT',
+                mutate(
+                  {
+                    baseRequest: {
+                      pageId,
+                      commandType: 'EDIT',
+                    },
+                    linkId: Number(id),
+                    linkName: title,
+                    linkUrl: link,
                   },
-                  linkId: Number(id),
-                  linkName: title,
-                  linkUrl: link,
-                });
-                setIsDropDownInline(false);
+                  {
+                    onSuccess: () => {
+                      setIsDropDownInline(false);
+                    },
+                    onError: (error) => {
+                      console.error('링크 수정 실패:', error);
+                      //Todo 사용자에게 에러 메시지 표시
+                    },
+                  }
+                );
               }}
               className="text-primary-60 flex cursor-pointer gap-[10px] p-[12px]"
             >

--- a/src/components/page-layout-ui/LinkItem.tsx
+++ b/src/components/page-layout-ui/LinkItem.tsx
@@ -52,6 +52,9 @@ export default function LinkItem({
         <ListBookmarkModal
           isBookmark={isBookmark}
           setIsBookmark={setIsBookmark}
+          itemId={item.id}
+          initialTitle={item.title}
+          initialLink={item.linkUrl}
         />
       </div>
     </div>

--- a/src/components/page-layout-ui/ListBookmarkOption.tsx
+++ b/src/components/page-layout-ui/ListBookmarkOption.tsx
@@ -7,11 +7,17 @@ import DropDownInline from '../common-ui/DropDownInline';
 interface ListBookmarkOptionInterface {
   isBookmark: boolean;
   setIsBookmark: React.Dispatch<React.SetStateAction<boolean>>;
+  itemId: string;
+  initialTitle: string;
+  initialLink?: string;
 }
 
 export default function ListBookMarkOption({
   isBookmark,
   setIsBookmark,
+  itemId,
+  initialTitle,
+  initialLink,
 }: ListBookmarkOptionInterface) {
   const [isDropDownInline, setIsDropDownInline] = useState(false);
 
@@ -23,6 +29,8 @@ export default function ListBookMarkOption({
     e.stopPropagation();
     setIsDropDownInline((prev) => !prev);
   };
+
+  console.log('ListBookMarkOptionItemId', itemId);
 
   return (
     <div className="relative flex items-center">
@@ -44,10 +52,10 @@ export default function ListBookMarkOption({
       </button>
       {isDropDownInline && (
         <DropDownInline
-          id="1"
+          id={itemId}
           type="site"
-          initialTitle="타이틀"
-          initialLink="링크"
+          initialTitle={initialTitle}
+          initialLink={initialLink ?? ''}
           className="absolute top-10 right-1 z-1"
           isDropDownInline={isDropDownInline}
           setIsDropDownInline={setIsDropDownInline}

--- a/src/components/page-layout-ui/ListBookmarkOption.tsx
+++ b/src/components/page-layout-ui/ListBookmarkOption.tsx
@@ -30,8 +30,6 @@ export default function ListBookMarkOption({
     setIsDropDownInline((prev) => !prev);
   };
 
-  console.log('ListBookMarkOptionItemId', itemId);
-
   return (
     <div className="relative flex items-center">
       <button

--- a/src/hooks/mutations/useCreateLink.ts
+++ b/src/hooks/mutations/useCreateLink.ts
@@ -1,12 +1,30 @@
+import {
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { createLink } from '@/apis/link-apis/createLink';
-import { CreateLinkData } from '@/types/links';
-import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { CreateLinkData, CreateLinkResponse } from '@/types/links';
 
 export function useCreateLink(
-  options?: UseMutationOptions<any, unknown, CreateLinkData>
+  options?: UseMutationOptions<CreateLinkResponse, unknown, CreateLinkData>
 ) {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: createLink,
-    ...options,
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({
+        queryKey: ['selectedPage', variables.baseRequest.pageId, 'VIEW'],
+      });
+
+      options?.onSuccess?.(data, variables, context);
+    },
+    onError: (error, variables, context) => {
+      options?.onError?.(error, variables, context);
+    },
+    onSettled: (data, error, variables, context) => {
+      options?.onSettled?.(data, error, variables, context);
+    },
   });
 }

--- a/src/hooks/mutations/useDeleteLink.ts
+++ b/src/hooks/mutations/useDeleteLink.ts
@@ -1,0 +1,29 @@
+import { deleteLink } from '@/apis/link-apis/deleteLink';
+import { DeleteLinkData } from '@/types/links';
+import {
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+export function useDeleteLink(
+  options?: UseMutationOptions<any, unknown, DeleteLinkData>
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteLink,
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({
+        queryKey: ['selectedPage', variables.baseRequest.pageId, 'VIEW'],
+      });
+      options?.onSuccess?.(data, variables, context);
+    },
+    onError: (error, variables, context) => {
+      options?.onError?.(error, variables, context);
+    },
+    onSettled: (data, error, variables, context) => {
+      options?.onSettled?.(data, error, variables, context);
+    },
+  });
+}

--- a/src/hooks/mutations/useDeleteLink.ts
+++ b/src/hooks/mutations/useDeleteLink.ts
@@ -1,5 +1,5 @@
 import { deleteLink } from '@/apis/link-apis/deleteLink';
-import { DeleteLinkData } from '@/types/links';
+import { DeleteLinkData, DeleteLinkResponse } from '@/types/links';
 import {
   useMutation,
   UseMutationOptions,
@@ -7,7 +7,7 @@ import {
 } from '@tanstack/react-query';
 
 export function useDeleteLink(
-  options?: UseMutationOptions<any, unknown, DeleteLinkData>
+  options?: UseMutationOptions<DeleteLinkResponse, unknown, DeleteLinkData>
 ) {
   const queryClient = useQueryClient();
 

--- a/src/hooks/mutations/useUpdateLink.ts
+++ b/src/hooks/mutations/useUpdateLink.ts
@@ -1,0 +1,29 @@
+import { updateLink } from '@/apis/link-apis/updateLink';
+import { UpdateLinkData, UpdateLinkResponse } from '@/types/links';
+import {
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+export function useUpdateLink(
+  options?: UseMutationOptions<UpdateLinkResponse, unknown, UpdateLinkData>
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateLink,
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({
+        queryKey: ['selectedPage', variables.baseRequest.pageId, 'VIEW'],
+      });
+      options?.onSuccess?.(data, variables, context);
+    },
+    onError: (error, variables, context) => {
+      options?.onError?.(error, variables, context);
+    },
+    onSettled: (data, error, variables, context) => {
+      options?.onSettled?.(data, error, variables, context);
+    },
+  });
+}

--- a/src/stores/linkActionStore.ts
+++ b/src/stores/linkActionStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+type LinkActionStore = {
+  deleteLink: (id: string) => void;
+  setDeleteLink: (fn: (id: string) => void) => void;
+};
+
+export const useLinkActionStore = create<LinkActionStore>((set) => ({
+  deleteLink: () => {},
+  setDeleteLink: (fn) => set({ deleteLink: fn }),
+}));

--- a/src/types/links.ts
+++ b/src/types/links.ts
@@ -1,10 +1,30 @@
+export type BaseRequest = {
+  pageId: number;
+  commandType: string;
+};
+
 export type CreateLinkData = {
-  baseRequest: {
-    pageId: number;
-    commandType: string;
-  };
+  baseRequest: BaseRequest;
   linkName: string;
   linkUrl: string;
   directoryId: number;
   faviconUrl: string;
+};
+
+export type DeleteLinkData = {
+  baseRequest: BaseRequest;
+  linkId: number;
+};
+
+export type UpdateLinkData = {
+  baseRequest: BaseRequest;
+  linkName: string;
+  linkUrl: string;
+  linkId: number;
+};
+
+export type UpdateLinkResponse = {
+  status: number;
+  message: string;
+  data: number;
 };

--- a/src/types/links.ts
+++ b/src/types/links.ts
@@ -1,6 +1,8 @@
+type CommandType = 'CREATE' | 'EDIT' | 'DELETE' | 'VIEW';
+
 export type BaseRequest = {
   pageId: number;
-  commandType: string;
+  commandType: CommandType;
 };
 
 export type CreateLinkData = {
@@ -23,8 +25,12 @@ export type UpdateLinkData = {
   linkId: number;
 };
 
-export type UpdateLinkResponse = {
+export type CommonApiResponse = {
   status: number;
   message: string;
   data: number;
 };
+
+export type CreateLinkResponse = CommonApiResponse;
+export type UpdateLinkResponse = CommonApiResponse;
+export type DeleteLinkResponse = CommonApiResponse;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- 링크 생성(createLink), 수정(updateLink), 삭제(deleteLink) API 구현
- useUpdateLink, useDeleteLink 커스텀 훅 생성 및 mutation 로직 분리
- DropDownInline.tsx에 링크 수정 및 삭제 기능 연결
- ListBookmarkOption.tsx에서 DropDownInline 연동 및 id 전달 처리
- PageControllerSection.tsx에서 deleteLink zustand store 연결
- zustand 기반 linkActionStore 추가
- 링크 관련 타입(links.ts) 정리 및 중복 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 링크 삭제, 수정 API 함수와 관련 훅이 새롭게 도입되어 호출 및 상태 관리가 개선되었습니다.
  - 링크 수정 시 "수정 완료" 버튼이 조건부로 표시되며, 클릭 시 수정 내용이 반영됩니다.
  - 링크 삭제 및 수정 후 관련 데이터가 자동으로 새로고침되어 최신 상태를 유지합니다.

- **개선 사항**
  - 컴포넌트들이 외부 상태와 연동되어 초기 데이터와 식별자를 유연하게 전달받도록 변경되었습니다.
  - 글로벌 링크 삭제 기능이 전역 상태 저장소를 통해 제어됩니다.

- **버그 수정**
  - 불필요한 콘솔 로그와 주석이 제거되고, 타입 명시가 강화되어 안정성이 향상되었습니다.

- **기타**
  - API 요청 및 응답 타입이 표준화되어 유지보수성과 확장성이 높아졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->