### PR TITLE
feat: 페이지 검색 기능 구현 및 공통 로직 리팩토링

### DIFF
--- a/src/apis/search-apis/searchPageItems.ts
+++ b/src/apis/search-apis/searchPageItems.ts
@@ -1,0 +1,13 @@
+import { PageItemSearchRequest, PageItemSearchResponse } from '@/types/search';
+import { axiosInstance } from '../axiosInstance';
+
+export async function searchPageItems(
+  data: PageItemSearchRequest
+): Promise<PageItemSearchResponse> {
+  try {
+    const response = await axiosInstance.post('/api/search', data);
+    return response.data.data;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/src/components/page-layout-ui/PageControllerSection.tsx
+++ b/src/components/page-layout-ui/PageControllerSection.tsx
@@ -17,6 +17,8 @@ import { useModalStore } from '@/stores/modalStore';
 export default function PageControllerSection({
   view,
   setView,
+  searchKeyword,
+  setSearchKeyword,
 }: PageControllerSectionProps) {
   const {
     isLinkModalOpen,
@@ -27,6 +29,7 @@ export default function PageControllerSection({
     closeFolderModal,
   } = useModalStore();
   const pageId = usePageStore((state) => state.pageId);
+
   const setDeleteLink = useLinkActionStore((state) => state.setDeleteLink);
   const { parentsFolderId } = useParentsFolderIdStore();
 
@@ -73,7 +76,12 @@ export default function PageControllerSection({
         </Button>
       </div>
       <div className="flex gap-[12px]">
-        <SearchBar size="fixed" placeholder="폴더, 링크 검색" />
+        <SearchBar
+          size="fixed"
+          placeholder="폴더, 링크 검색"
+          value={searchKeyword}
+          onChange={(e) => setSearchKeyword(e.target.value)}
+        />
         <PageSortBox />
         <div className="hidden lg:block">
           <ViewToggle selectedView={view} onChange={setView} />

--- a/src/components/page-layout-ui/PersonalPageContentSection.tsx
+++ b/src/components/page-layout-ui/PersonalPageContentSection.tsx
@@ -10,6 +10,7 @@ import { useModalStore } from '@/stores/modalStore';
 
 export default function PersonalPageContentSection({
   view,
+  searchResult,
 }: PageContentSectionProps) {
   const { openLinkModal, openFolderModal } = useModalStore();
   const [isBookmark, setIsBookmark] = useState(false);
@@ -49,9 +50,15 @@ export default function PersonalPageContentSection({
 
   const folderData = selectedPageQuery.data?.data.directoryDetailRespons ?? [];
   const linkData = selectedPageQuery.data?.data.siteDetailResponses ?? [];
-  const mergedList = [...folderData, ...linkData].sort(
-    (a, b) => a.orderIndex - b.orderIndex
-  );
+  const mergedList = searchResult
+    ? [
+        ...(searchResult.directorySimpleResponses ?? []),
+        ...(searchResult.siteSimpleResponses ?? []),
+      ].map((item, index) => ({
+        ...item,
+        orderIndex: index, // orderIndex는 없기 때문에 임의 부여
+      }))
+    : [...folderData, ...linkData].sort((a, b) => a.orderIndex - b.orderIndex);
 
   console.log('합친 데이터', mergedList);
 
@@ -71,7 +78,7 @@ export default function PersonalPageContentSection({
           if ('folderId' in item) {
             return (
               <FolderItem
-                key={item.orderIndex}
+                key={`folder-${item.folderId}`}
                 isBookmark={item.isFavorite}
                 setIsBookmark={setIsBookmark}
                 item={{ id: item.folderId, title: item.folderName }}
@@ -81,7 +88,7 @@ export default function PersonalPageContentSection({
           } else if ('linkId' in item) {
             return (
               <LinkItem
-                key={item.orderIndex}
+                key={`link-${item.linkId}`}
                 isBookmark={item.isFavorite}
                 setIsBookmark={setIsBookmark}
                 item={{

--- a/src/components/page-layout-ui/SharedPageContentSection.tsx
+++ b/src/components/page-layout-ui/SharedPageContentSection.tsx
@@ -3,11 +3,14 @@ import FolderItem from './FolderItem';
 import LinkItem from './LinkItem';
 import { ContextMenu } from '../common-ui/ContextMenu';
 import { PageContentSectionProps } from '@/types/pageItems';
+import { useModalStore } from '@/stores/modalStore';
 
 export default function SharedPageContentSection({
   view,
   contentData,
+  searchResult,
 }: PageContentSectionProps) {
+  const { openLinkModal, openFolderModal } = useModalStore();
   const [isBookmark, setIsBookmark] = useState(false);
   const [contextMenu, setContextMenu] = useState<{
     x: number;
@@ -18,12 +21,19 @@ export default function SharedPageContentSection({
     e.preventDefault();
     setContextMenu({ x: e.clientX, y: e.clientY });
   };
+  console.log('contentData:', contentData);
 
   const folderData = contentData?.directoryDetailRespons ?? [];
   const linkData = contentData?.siteDetailResponses ?? [];
-  const mergedList = [...folderData, ...linkData].sort(
-    (a, b) => a.orderIndex - b.orderIndex
-  );
+  const mergedList = searchResult
+    ? [
+        ...(searchResult.directorySimpleResponses ?? []),
+        ...(searchResult.siteSimpleResponses ?? []),
+      ].map((item, index) => ({
+        ...item,
+        orderIndex: index, // orderIndex는 없기 때문에 임의 부여
+      }))
+    : [...folderData, ...linkData].sort((a, b) => a.orderIndex - b.orderIndex);
   console.log('합친 데이터', mergedList);
 
   return (
@@ -72,6 +82,8 @@ export default function SharedPageContentSection({
             x={contextMenu.x}
             y={contextMenu.y}
             onClose={() => setContextMenu(null)}
+            onAddFolder={openFolderModal}
+            onAddLink={openLinkModal}
           />
         )}
       </div>

--- a/src/hooks/queries/useSearchPageItems.ts
+++ b/src/hooks/queries/useSearchPageItems.ts
@@ -1,0 +1,14 @@
+import { searchPageItems } from '@/apis/search-apis/searchPageItems';
+import { PageItemSearchRequest } from '@/types/search';
+import { useQuery } from '@tanstack/react-query';
+
+export function useSearchPageItems(params: PageItemSearchRequest) {
+  const { data, ...rest } = useQuery({
+    queryKey: ['searchPageItems', params],
+    queryFn: () => searchPageItems(params),
+    select: (response) => response,
+    enabled: !!params.pageId && !!params.keyword,
+  });
+
+  return { pageItems: data, ...rest };
+}

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/src/hooks/usePageSearch.ts
+++ b/src/hooks/usePageSearch.ts
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import { useDebounce } from './useDebounce';
+import { useSearchPageItems } from './queries/useSearchPageItems';
+
+export function usePageSearch(pageId: number | undefined) {
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const debouncedKeyword = useDebounce(searchKeyword, 300);
+
+  const { pageItems, isSuccess } = useSearchPageItems({
+    pageId: pageId ?? 0, // pageId 없을 때 기본값 (서버 요청 안 나가도록 enabled 처리됨)
+    keyword: debouncedKeyword,
+    searchType: 'TITLE',
+  });
+
+  const searchResult = isSuccess ? pageItems : undefined;
+
+  return {
+    searchKeyword,
+    setSearchKeyword,
+    searchResult,
+  };
+}

--- a/src/pages/BookmarkPage.tsx
+++ b/src/pages/BookmarkPage.tsx
@@ -3,8 +3,14 @@ import { useMobile } from '@/hooks/useMobile';
 import PageHeaderSection from '@/components/page-layout-ui/PageHeaderSection';
 import PageControllerSection from '@/components/page-layout-ui/PageControllerSection';
 import BookmarkPageContentSection from '@/components/page-layout-ui/BookmarkPageContentSection';
+import { usePageStore } from '@/stores/pageStore';
+import { usePageSearch } from '@/hooks/usePageSearch';
 export default function BookmarkPage() {
   const [view, setView] = useState<'grid' | 'list'>('grid');
+  const pageId = usePageStore((state) => state.pageId);
+
+  const { searchKeyword, setSearchKeyword, searchResult } =
+    usePageSearch(pageId);
 
   const isMobile = useMobile();
 
@@ -26,10 +32,15 @@ export default function BookmarkPage() {
       <div className="border-b-gray-30 mb-[40px] w-full border-b" />
 
       {/* CONTROLLER SECTION*/}
-      <PageControllerSection view={view} setView={setView} />
+      <PageControllerSection
+        view={view}
+        setView={setView}
+        searchKeyword={searchKeyword}
+        setSearchKeyword={setSearchKeyword}
+      />
 
       {/*CONTENT SECTION*/}
-      <BookmarkPageContentSection view={view} />
+      <BookmarkPageContentSection view={view} searchResult={searchResult} />
     </div>
   );
 }

--- a/src/pages/PersonalPage.tsx
+++ b/src/pages/PersonalPage.tsx
@@ -3,12 +3,18 @@ import PageHeaderSection from '@/components/page-layout-ui/PageHeaderSection';
 import PersonalPageContentSection from '@/components/page-layout-ui/PersonalPageContentSection';
 import { useFetchPersonalPage } from '@/hooks/queries/useFetchPersonalPage';
 import { useMobile } from '@/hooks/useMobile';
+import { usePageSearch } from '@/hooks/usePageSearch';
+import { usePageStore } from '@/stores/pageStore';
 import { useUserStore } from '@/stores/userStore';
 import { useEffect, useState } from 'react';
 
 export default function PersonalPage() {
   const { member, pageDetails, isLoading, error } = useFetchPersonalPage();
   const setUser = useUserStore((state) => state.setUser);
+  const pageId = usePageStore((state) => state.pageId);
+
+  const { searchKeyword, setSearchKeyword, searchResult } =
+    usePageSearch(pageId);
 
   const [view, setView] = useState<'grid' | 'list'>('grid');
 
@@ -43,10 +49,15 @@ export default function PersonalPage() {
       <div className="border-b-gray-30 mb-[40px] w-full border-b" />
 
       {/* CONTROLLER SECTION*/}
-      <PageControllerSection view={view} setView={setView} />
+      <PageControllerSection
+        view={view}
+        setView={setView}
+        searchKeyword={searchKeyword}
+        setSearchKeyword={setSearchKeyword}
+      />
 
       {/*CONTENT SECTION*/}
-      <PersonalPageContentSection view={view} />
+      <PersonalPageContentSection view={view} searchResult={searchResult} />
     </div>
   );
 }

--- a/src/pages/SharedPage.tsx
+++ b/src/pages/SharedPage.tsx
@@ -8,6 +8,7 @@ import PageHeaderSection from '@/components/page-layout-ui/PageHeaderSection';
 import PageControllerSection from '@/components/page-layout-ui/PageControllerSection';
 import useFetchSharedPageDashboard from '@/hooks/queries/useFetchSharedPageDashboard';
 import useFetchSharedPageMember from '@/hooks/queries/useFetchSharedPageMember';
+import { usePageSearch } from '@/hooks/usePageSearch';
 
 export default function SharedPage() {
   const [view, setView] = useState<'grid' | 'list'>('grid');
@@ -27,6 +28,8 @@ export default function SharedPage() {
   if (pageId) {
     resolvedPageId = parseInt(pageId);
   }
+  const { searchKeyword, setSearchKeyword, searchResult } =
+    usePageSearch(resolvedPageId);
 
   // 클릭해서 들어간 페이지 정보 전역 변수로tj 저장
   const { setPageInfo } = usePageStore();
@@ -78,12 +81,18 @@ export default function SharedPage() {
       <div className="border-b-gray-30 mb-[40px] w-full border-b" />
 
       {/* CONTROLLER SECTION*/}
-      <PageControllerSection view={view} setView={setView} />
+      <PageControllerSection
+        view={view}
+        setView={setView}
+        searchKeyword={searchKeyword}
+        setSearchKeyword={setSearchKeyword}
+      />
 
       {/*CONTENT SECTION*/}
       <SharedPageContentSection
         view={view}
         contentData={selectedPageQuery.data?.data}
+        searchResult={searchResult}
       />
     </div>
   );

--- a/src/types/pageItems.ts
+++ b/src/types/pageItems.ts
@@ -1,3 +1,5 @@
+import { PageItemSearchResponse } from './search';
+
 export type ViewType = 'grid' | 'list';
 
 export interface ContentData {
@@ -26,8 +28,12 @@ export interface PageItemProps {
 export interface PageContentSectionProps {
   view: ViewType;
   contentData?: any;
+  searchResult?: PageItemSearchResponse;
 }
 
-export interface PageControllerSectionProps extends PageContentSectionProps {
+export interface PageControllerSectionProps {
+  view: ViewType;
   setView: React.Dispatch<React.SetStateAction<'list' | 'grid'>>;
+  searchKeyword: string;
+  setSearchKeyword: React.Dispatch<React.SetStateAction<string>>;
 }

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,0 +1,20 @@
+export type PageItemSearchRequest = {
+  pageId: number;
+  keyword: string;
+  searchType: string;
+};
+
+export type PageItemSearchResponse = {
+  directorySimpleResponses: Array<{
+    folderId: string;
+    folderName: string;
+    isFavorite: boolean;
+  }>;
+  siteSimpleResponses: Array<{
+    linkId: string;
+    linkName: string;
+    linkUrl: string;
+    isFavorite: boolean;
+    faviconUrl: string;
+  }>;
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- usePageSearch 훅 추가로 페이지 검색 로직 공통화
- useDebounce, useSearchPageItems 훅 분리 및 구현
- PersonalPage, SharedPage 검색 기능 적용
- BookmarkPage는 북마크 기능 추가 후 구현 예정
- PageControllerSection에서 검색 키워드 입력 관리
- PersonalPageContentSection, SharedPageContentSection에서 검색 결과 반영하도록 수정
- 관련 타입 정의 추가 (types/search.ts 등)