### PR TITLE
feat: 폴더 crud 구현 및 query key 임시 통일

### DIFF
--- a/src/apis/folder-apis/deleteFolder.ts
+++ b/src/apis/folder-apis/deleteFolder.ts
@@ -1,0 +1,14 @@
+import { DeleteFolderData } from '@/types/folders';
+import { axiosInstance } from '../axiosInstance';
+
+export default async function deleteFolder(data: DeleteFolderData) {
+  try {
+    const response = await axiosInstance.delete('/api/folders', {
+      data,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error deleting folder:', error);
+    throw error;
+  }
+}

--- a/src/apis/folder-apis/fetchFolderDetails.ts
+++ b/src/apis/folder-apis/fetchFolderDetails.ts
@@ -1,0 +1,21 @@
+import { axiosInstance } from '../axiosInstance';
+import { FetchFolderDetailsProps } from '@/types/folders';
+
+export default async function fetchFolderDetails(
+  data: FetchFolderDetailsProps
+) {
+  try {
+    const response = await axiosInstance.get('/api/folders/details', {
+      params: {
+        pageId: data.pageId,
+        commandType: data.commandType,
+        folderId: data.folderId,
+        sortType: data.sortType,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching folder details:', error);
+    throw error;
+  }
+}

--- a/src/apis/folder-apis/updateFolder.ts
+++ b/src/apis/folder-apis/updateFolder.ts
@@ -1,0 +1,12 @@
+import { UpdateFolderData } from '@/types/folders';
+import { axiosInstance } from '../axiosInstance';
+
+export default async function updateFolder(data: UpdateFolderData) {
+  try {
+    const response = await axiosInstance.put('/api/folders', data);
+    return response.data;
+  } catch (error: unknown) {
+    console.error('Error updating folder:', error);
+    throw error;
+  }
+}

--- a/src/components/common-ui/DropDownInline.tsx
+++ b/src/components/common-ui/DropDownInline.tsx
@@ -3,18 +3,16 @@ import Transfer from '@/assets/common-ui-assets/Transfer.svg?react';
 import Copy from '@/assets/common-ui-assets/Copy.svg?react';
 import Delete from '@/assets/common-ui-assets/Delete.svg?react';
 import { useClickOutside } from '@/hooks/useClickOutside';
-
+import useDeleteFolder from '@/hooks/mutations/useDeleteFolder';
+import { usePageStore } from '@/stores/pageStore';
 type DropDownInlineProps = {
-  id: string;
-  type: 'directory' | 'site';
+  id: number;
+  type: string;
   initialTitle: string;
   initialLink: string;
 
-  onDelete?: (id: string) => void;
-  onShare?: (id: string) => void;
-  onCopy?: (title: string) => void;
-  onTitleChange?: (id: string, title: string) => void;
-  onLinkChange?: (id: string, link: string) => void;
+  onTitleChange?: (id: number, title: string) => void;
+  onLinkChange?: (id: number, link: string) => void;
   className?: string;
   isDropDownInline: boolean;
   setIsDropDownInline: React.Dispatch<React.SetStateAction<boolean>>;
@@ -25,14 +23,13 @@ const DropDownInline = ({
   type,
   initialTitle = '',
   initialLink = '',
-  onDelete,
-  onShare,
-  onCopy,
+
   onTitleChange,
   onLinkChange,
   setIsDropDownInline,
   className,
 }: DropDownInlineProps) => {
+  const { pageId, commandType } = usePageStore();
   const [title, setTitle] = useState(initialTitle);
   const [link, setLink] = useState(initialLink);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -49,15 +46,28 @@ const DropDownInline = ({
     onLinkChange?.(id, value);
   };
 
+  const { mutate: deleteFolder } = useDeleteFolder(pageId, commandType);
+
+  const handleDelete = () => {
+    const requestBody = {
+      baseRequest: {
+        pageId,
+        commandType: 'DELETE',
+      },
+      folderId: id,
+    };
+    console.log('폴더 삭제 요청 데이터:', requestBody);
+    deleteFolder(requestBody);
+  };
+
   useClickOutside(dropdownRef, setIsDropDownInline);
 
-  // TODO : 삭제하기 disabled의 경우, auth가 추가되면 분기처리예정
   return (
     <div
       ref={dropdownRef}
       className={`border-gray-30 focus:bg-gray-30 focus:border-gray-30 bg-gray-0 inline-flex w-[214px] flex-col rounded-[10px] border p-[8px] text-[14px] font-[600] shadow ${className}`}
     >
-      {type === 'directory' && (
+      {type === 'folder' && (
         <div className="flex flex-col">
           <input
             value={title}
@@ -66,19 +76,19 @@ const DropDownInline = ({
             className="border-gray-30 rounded-lg border p-[8px] outline-none"
           />
           <button
-            onClick={() => onShare?.(id)}
+            onClick={() => console.log('전송')}
             className="flex cursor-pointer items-center gap-[10px] px-[8px] py-[11px]"
           >
             <Transfer width={18} height={18} /> 전송하기
           </button>
           <button
-            onClick={() => onCopy?.(title)}
+            onClick={() => console.log('복사')}
             className="flex cursor-pointer items-center gap-[10px] px-[8px] py-[11px]"
           >
             <Copy width={18} height={18} /> 복사하기
           </button>
           <button
-            onClick={() => onDelete?.(id)}
+            onClick={handleDelete}
             className="text-status-danger flex cursor-pointer items-center gap-[10px] px-[8px] py-[11px]"
           >
             <Delete width={18} height={18} /> 삭제하기
@@ -86,7 +96,7 @@ const DropDownInline = ({
         </div>
       )}
 
-      {type === 'site' && (
+      {type === 'link' && (
         <div className="flex flex-col">
           <div className="border-gray-30 flex flex-col overflow-hidden rounded-lg border">
             <input
@@ -103,13 +113,13 @@ const DropDownInline = ({
             />
           </div>
           <button
-            onClick={() => onShare?.(id)}
+            onClick={() => console.log('전송')}
             className="flex cursor-pointer items-center gap-[10px] p-[12px]"
           >
             <Transfer width={18} height={18} /> 전송하기
           </button>
           <button
-            onClick={() => onDelete?.(id)}
+            onClick={() => console.log('삭제')}
             className="text-status-danger flex cursor-pointer items-center gap-[10px] p-[12px]"
           >
             <Delete width={18} height={18} /> 삭제하기

--- a/src/components/common-ui/DropDownInline.tsx
+++ b/src/components/common-ui/DropDownInline.tsx
@@ -5,6 +5,7 @@ import Delete from '@/assets/common-ui-assets/Delete.svg?react';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import useDeleteFolder from '@/hooks/mutations/useDeleteFolder';
 import { usePageStore } from '@/stores/pageStore';
+import DeleteFolderModal from '../modal/folder/DeleteFolderModal';
 type DropDownInlineProps = {
   id: number;
   type: string;
@@ -29,9 +30,10 @@ const DropDownInline = ({
   setIsDropDownInline,
   className,
 }: DropDownInlineProps) => {
-  const { pageId, commandType } = usePageStore();
+  const { pageId } = usePageStore();
   const [title, setTitle] = useState(initialTitle);
   const [link, setLink] = useState(initialLink);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -46,21 +48,11 @@ const DropDownInline = ({
     onLinkChange?.(id, value);
   };
 
-  const { mutate: deleteFolder } = useDeleteFolder(pageId, commandType);
-
-  const handleDelete = () => {
-    const requestBody = {
-      baseRequest: {
-        pageId,
-        commandType: 'EDIT',
-      },
-      folderId: id,
-    };
-    console.log('폴더 삭제 요청 데이터:', requestBody);
-    deleteFolder(requestBody);
+  const handleDeleteOpen = () => {
+    setIsDeleteOpen(true);
   };
 
-  useClickOutside(dropdownRef, setIsDropDownInline);
+  useClickOutside(dropdownRef, setIsDropDownInline, !isDeleteOpen);
 
   return (
     <div
@@ -88,11 +80,20 @@ const DropDownInline = ({
             <Copy width={18} height={18} /> 복사하기
           </button>
           <button
-            onClick={handleDelete}
+            onClick={handleDeleteOpen}
             className="text-status-danger flex cursor-pointer items-center gap-[10px] px-[8px] py-[11px]"
           >
             <Delete width={18} height={18} /> 삭제하기
           </button>
+
+          {isDeleteOpen && (
+            <DeleteFolderModal
+              isOpen={isDeleteOpen}
+              onClose={() => setIsDeleteOpen(false)}
+              folderId={id}
+              pageId={pageId}
+            />
+          )}
         </div>
       )}
 

--- a/src/components/common-ui/DropDownInline.tsx
+++ b/src/components/common-ui/DropDownInline.tsx
@@ -52,7 +52,7 @@ const DropDownInline = ({
     const requestBody = {
       baseRequest: {
         pageId,
-        commandType: 'DELETE',
+        commandType: 'EDIT',
       },
       folderId: id,
     };

--- a/src/components/common-ui/DropDownInline.tsx
+++ b/src/components/common-ui/DropDownInline.tsx
@@ -6,6 +6,7 @@ import { useClickOutside } from '@/hooks/useClickOutside';
 import { useLinkActionStore } from '@/stores/linkActionStore';
 import { useUpdateLink } from '@/hooks/mutations/useUpdateLink';
 import { usePageStore } from '@/stores/pageStore';
+import DeleteFolderModal from '../modal/folder/DeleteFolderModal';
 
 type DropDownInlineProps = {
   id: number;
@@ -31,7 +32,6 @@ const DropDownInline = ({
   setIsDropDownInline,
   className,
 }: DropDownInlineProps) => {
-  const { pageId } = usePageStore();
   const [title, setTitle] = useState(initialTitle);
   const [link, setLink] = useState(initialLink);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);

--- a/src/components/common-ui/Modal.tsx
+++ b/src/components/common-ui/Modal.tsx
@@ -129,7 +129,7 @@ const ConfirmButton = ({
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        `rounded-lg px-5 py-3 ${variantClasses[variant]}`,
+        `cursor-pointer rounded-lg px-5 py-3 ${variantClasses[variant]}`,
         className
       )}
     >
@@ -155,7 +155,7 @@ const CancelButton = ({
         onClose();
       }}
       className={cn(
-        'rounded-lg border border-[var(--color-gray-20)] px-5 py-3',
+        'cursor-pointer rounded-lg border border-[var(--color-gray-20)] px-5 py-3',
         className
       )}
     >

--- a/src/components/modal/folder/AddFolderModal.tsx
+++ b/src/components/modal/folder/AddFolderModal.tsx
@@ -20,8 +20,6 @@ export default function AddFolderModal({
   const { pageId, commandType } = usePageStore();
   const { parentsFolderId } = useParentsFolderIdStore();
 
-  console.log('현재 폴더 id', parentsFolderId);
-
   const isConfirmDisabled = !folderName;
 
   const createFolderMutation = useCreateFolder(pageId, commandType, {

--- a/src/components/modal/folder/AddFolderModal.tsx
+++ b/src/components/modal/folder/AddFolderModal.tsx
@@ -17,14 +17,14 @@ export default function AddFolderModal({
   const [folderName, setFolderName] = useState('');
   const [folderDescription, setFolderDescription] = useState('');
   const [error, setError] = useState('');
-  const { pageId: id, commandType: type } = usePageStore();
+  const { pageId, commandType } = usePageStore();
   const { parentsFolderId } = useParentsFolderIdStore();
 
   console.log('현재 폴더 id', parentsFolderId);
 
   const isConfirmDisabled = !folderName;
 
-  const createFolderMutation = useCreateFolder({
+  const createFolderMutation = useCreateFolder(pageId, commandType, {
     onSuccess: () => {
       setFolderName('');
       setFolderDescription('');
@@ -46,11 +46,11 @@ export default function AddFolderModal({
 
     const requestBody = {
       baseRequest: {
-        pageId: id,
-        commandType: type,
+        pageId,
+        commandType,
       },
       folderName,
-      parentFolderId: parentsFolderId,
+      parentFolderId: parentsFolderId ?? 1,
       folderDescription,
     };
 

--- a/src/components/modal/folder/DeleteFolderModal.tsx
+++ b/src/components/modal/folder/DeleteFolderModal.tsx
@@ -1,33 +1,31 @@
-import { useState } from 'react';
 import Modal from '@/components/common-ui/Modal';
 import Status from '@/assets/common-ui-assets/Status.svg?react';
+import useDeleteFolder from '@/hooks/mutations/useDeleteFolder';
 
 const DeleteFolderModal = ({
   isOpen,
   onClose,
-  onSubmit,
   folderId,
+  pageId,
 }: {
   isOpen: boolean;
   onClose: () => void;
-  folderId: number | null;
-  onSubmit: (folderId: null | number) => Promise<void>;
+  folderId: number;
+  pageId: number;
 }) => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { mutate: deleteFolder } = useDeleteFolder(pageId, 'EDIT');
 
-  const handleSubmit = async (folderId: number | null) => {
-    setIsSubmitting(true);
-
-    try {
-      console.log('삭제할 폴더 ID:', folderId);
-      await onSubmit(folderId);
-      onClose();
-    } catch (error) {
-      console.error('폴더 삭제 오류:', error);
-      // Todo 에러 로직 추가 필요
-    } finally {
-      setIsSubmitting(false);
-    }
+  const handleDelete = () => {
+    const requestBody = {
+      baseRequest: {
+        pageId,
+        commandType: 'EDIT',
+      },
+      folderId: folderId,
+    };
+    console.log('폴더 삭제 요청 데이터:', requestBody);
+    deleteFolder(requestBody);
+    onClose();
   };
 
   return (
@@ -44,12 +42,7 @@ const DeleteFolderModal = ({
 
       <Modal.Footer className="pt-0">
         <Modal.CancelButton />
-        <Modal.ConfirmButton
-          onClick={() => handleSubmit(folderId)}
-          disabled={isSubmitting}
-        >
-          삭제
-        </Modal.ConfirmButton>
+        <Modal.ConfirmButton onClick={handleDelete}>삭제</Modal.ConfirmButton>
       </Modal.Footer>
     </Modal>
   );

--- a/src/components/modal/folder/DeleteFolderModal.tsx
+++ b/src/components/modal/folder/DeleteFolderModal.tsx
@@ -13,7 +13,7 @@ const DeleteFolderModal = ({
   folderId: number;
   pageId: number;
 }) => {
-  const { mutate: deleteFolder } = useDeleteFolder(pageId, 'EDIT');
+  const { mutate: deleteFolder } = useDeleteFolder(pageId);
 
   const handleDelete = () => {
     const requestBody = {

--- a/src/components/page-layout-ui/FolderItem.tsx
+++ b/src/components/page-layout-ui/FolderItem.tsx
@@ -50,7 +50,8 @@ export default function FolderItem({
         <ListBookmarkModal
           isBookmark={isBookmark}
           setIsBookmark={setIsBookmark}
-          item={item}
+          itemId={item.id}
+          initialTitle={item.title}
           type={type}
         />
       </div>

--- a/src/components/page-layout-ui/FolderItem.tsx
+++ b/src/components/page-layout-ui/FolderItem.tsx
@@ -3,6 +3,7 @@ import ListBookmarkModal from './ListBookmarkOption';
 import InactiveBookmarkIcon from '@/assets/common-ui-assets/FolderBookmarkInactive.svg?react';
 import ActiveBookmarkIcon from '@/assets/common-ui-assets/FolderBookmarkActive.svg?react';
 import { PageItemProps } from '@/types/pageItems';
+import { useNavigate } from 'react-router-dom';
 
 export default function FolderItem({
   item,
@@ -11,9 +12,18 @@ export default function FolderItem({
   setIsBookmark,
 }: PageItemProps) {
   const isGrid = view === 'grid';
+  const type = 'folder';
+  const navigate = useNavigate();
+
+  const handleDoubleClick = () => {
+    navigate(`folder/${item.id}`);
+  };
 
   return isGrid ? (
-    <div className="bg-gray-0 hover:bg-gray-5 active:bg-gray-5 relative inline-flex w-full cursor-pointer flex-col items-center gap-2 rounded-[8px] p-[12px]">
+    <div
+      className="bg-gray-0 hover:bg-gray-5 active:bg-gray-5 relative inline-flex w-full cursor-pointer flex-col items-center gap-2 rounded-[8px] p-[12px]"
+      onDoubleClick={handleDoubleClick}
+    >
       <FolderItemIcon />
       <button
         className="absolute top-10 right-5 cursor-pointer bg-transparent"
@@ -26,7 +36,10 @@ export default function FolderItem({
       </span>
     </div>
   ) : (
-    <div className="border-gray-30 hover:bg-gray-5 active:bg-gray-5 flex w-full items-center justify-between border-b px-[12px] py-[16px] last:border-b-0">
+    <div
+      className="border-gray-30 hover:bg-gray-5 active:bg-gray-5 flex w-full items-center justify-between border-b px-[12px] py-[16px] last:border-b-0"
+      onDoubleClick={handleDoubleClick}
+    >
       <div className="flex items-center gap-[20px]">
         <FolderItemIcon width={42} height={38} />
         <span className="text-gray-90 text-[14px] font-[400]">
@@ -37,6 +50,8 @@ export default function FolderItem({
         <ListBookmarkModal
           isBookmark={isBookmark}
           setIsBookmark={setIsBookmark}
+          item={item}
+          type={type}
         />
       </div>
     </div>

--- a/src/components/page-layout-ui/LinkItem.tsx
+++ b/src/components/page-layout-ui/LinkItem.tsx
@@ -11,6 +11,7 @@ export default function LinkItem({
   setIsBookmark,
 }: PageItemProps) {
   const isGrid = view === 'grid';
+  const type = 'link';
 
   const handleDoubleClick = () => {
     if ('linkUrl' in item) {
@@ -52,6 +53,8 @@ export default function LinkItem({
         <ListBookmarkModal
           isBookmark={isBookmark}
           setIsBookmark={setIsBookmark}
+          item={item}
+          type={type}
         />
       </div>
     </div>

--- a/src/components/page-layout-ui/LinkItem.tsx
+++ b/src/components/page-layout-ui/LinkItem.tsx
@@ -56,6 +56,7 @@ export default function LinkItem({
           itemId={item.id}
           initialTitle={item.title}
           initialLink={item.linkUrl}
+          type={type}
         />
       </div>
     </div>

--- a/src/components/page-layout-ui/ListBookmarkOption.tsx
+++ b/src/components/page-layout-ui/ListBookmarkOption.tsx
@@ -3,15 +3,22 @@ import ActiveBookmarkIcon from '@/assets/common-ui-assets/ActiveBookmarkIcon.svg
 import Menu from '@/assets/widget-ui-assets/Menu.svg?react';
 import { useState } from 'react';
 import DropDownInline from '../common-ui/DropDownInline';
-
 interface ListBookmarkOptionInterface {
   isBookmark: boolean;
   setIsBookmark: React.Dispatch<React.SetStateAction<boolean>>;
+  item: {
+    id: number;
+    title: string;
+    linkUrl?: string;
+  };
+  type: string;
 }
 
 export default function ListBookMarkOption({
   isBookmark,
   setIsBookmark,
+  item,
+  type,
 }: ListBookmarkOptionInterface) {
   const [isDropDownInline, setIsDropDownInline] = useState(false);
 
@@ -44,10 +51,10 @@ export default function ListBookMarkOption({
       </button>
       {isDropDownInline && (
         <DropDownInline
-          id="1"
-          type="site"
-          initialTitle="타이틀"
-          initialLink="링크"
+          id={item.id}
+          type={type}
+          initialTitle={item.title}
+          initialLink={item.linkUrl ?? ''}
           className="absolute top-10 right-1 z-1"
           isDropDownInline={isDropDownInline}
           setIsDropDownInline={setIsDropDownInline}

--- a/src/components/page-layout-ui/ListBookmarkOption.tsx
+++ b/src/components/page-layout-ui/ListBookmarkOption.tsx
@@ -6,9 +6,10 @@ import DropDownInline from '../common-ui/DropDownInline';
 interface ListBookmarkOptionInterface {
   isBookmark: boolean;
   setIsBookmark: React.Dispatch<React.SetStateAction<boolean>>;
-  itemId: string;
+  itemId: number;
   initialTitle: string;
   initialLink?: string;
+  type: string;
 }
 
 export default function ListBookMarkOption({
@@ -17,6 +18,7 @@ export default function ListBookMarkOption({
   itemId,
   initialTitle,
   initialLink,
+  type,
 }: ListBookmarkOptionInterface) {
   const [isDropDownInline, setIsDropDownInline] = useState(false);
 
@@ -50,7 +52,7 @@ export default function ListBookMarkOption({
       {isDropDownInline && (
         <DropDownInline
           id={itemId}
-          type="site"
+          type={type}
           initialTitle={initialTitle}
           initialLink={initialLink ?? ''}
           className="absolute top-10 right-1 z-1"

--- a/src/components/page-layout-ui/ListBookmarkOption.tsx
+++ b/src/components/page-layout-ui/ListBookmarkOption.tsx
@@ -10,6 +10,7 @@ interface ListBookmarkOptionInterface {
   initialTitle: string;
   initialLink?: string;
   type: string;
+  pageDescription?: string;
 }
 
 export default function ListBookMarkOption({
@@ -19,6 +20,7 @@ export default function ListBookMarkOption({
   initialTitle,
   initialLink,
   type,
+  pageDescription,
 }: ListBookmarkOptionInterface) {
   const [isDropDownInline, setIsDropDownInline] = useState(false);
 
@@ -58,6 +60,7 @@ export default function ListBookMarkOption({
           className="absolute top-10 right-1 z-1"
           isDropDownInline={isDropDownInline}
           setIsDropDownInline={setIsDropDownInline}
+          pageDescription={pageDescription ?? ''}
         />
       )}
     </div>

--- a/src/components/page-layout-ui/PageControllerSection.tsx
+++ b/src/components/page-layout-ui/PageControllerSection.tsx
@@ -9,7 +9,7 @@ import { useState } from 'react';
 import AddFolderModal from '../modal/folder/AddFolderModal';
 import AddLinkModal from '../modal/link/AddLinkModal';
 import { useCreateLink } from '@/hooks/mutations/useCreateLink';
-import { usePageStore } from '@/stores/pageStore';
+import { usePageStore, useParentsFolderIdStore } from '@/stores/pageStore';
 
 export default function PageControllerSection({
   view,
@@ -18,6 +18,7 @@ export default function PageControllerSection({
   const [isFolderOpen, setIsFolderOpen] = useState(false);
   const [isLinkOpen, setIsLinkOpen] = useState(false);
   const pageId = usePageStore((state) => state.pageId);
+  const { parentsFolderId } = useParentsFolderIdStore();
 
   const { mutate: createLink } = useCreateLink({
     onSuccess: () => {
@@ -75,7 +76,7 @@ export default function PageControllerSection({
               },
               linkName,
               linkUrl,
-              directoryId: 1, // 실제 폴더 ID
+              directoryId: parentsFolderId ?? 1, // 실제 폴더 ID
               faviconUrl: `${linkUrl}/favicon.ico`,
             });
           }}

--- a/src/components/page-layout-ui/PageControllerSection.tsx
+++ b/src/components/page-layout-ui/PageControllerSection.tsx
@@ -34,13 +34,13 @@ export default function PageControllerSection({
   const { mutate: deleteLinkMutate } = useDeleteLink();
 
   const deleteHandler = useCallback(
-    (id: string) => {
+    (id: number) => {
       deleteLinkMutate({
         baseRequest: {
           pageId,
           commandType: 'EDIT',
         },
-        linkId: Number(id),
+        linkId: id,
       });
     },
     [deleteLinkMutate, pageId]

--- a/src/components/page-layout-ui/PageHeaderSection.tsx
+++ b/src/components/page-layout-ui/PageHeaderSection.tsx
@@ -1,49 +1,145 @@
-// import { useState } from 'react';
-
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import { usePageStore } from '@/stores/pageStore';
+import useUpdateFolder from '@/hooks/mutations/useUpdateFolder';
+import { useDebounce } from '@/hooks/useDebounce';
 
 type PageHeaderSectionProps = {
   pageTitle: string;
   pageDescription: string;
+  folderId?: number;
 };
+
+type FolderUpdateData = {
+  title: string;
+  description: string;
+};
+
+const MAX_TITLE_LENGTH = 21;
+const MAX_DESCRIPTION_LENGTH = 500;
 
 export default function PageHeaderSection({
   pageTitle,
   pageDescription,
+  folderId,
 }: PageHeaderSectionProps) {
-  // TODO:추후 title,setTItle을 활용하여 데이터 수정을 통해 페이지 제목, 소개글 변경
-  const [title, setTitle] = useState('');
-  const [description, setDescription] = useState('');
+  const [title, setTitle] = useState(pageTitle ?? '');
+  const [description, setDescription] = useState(pageDescription ?? '');
+  const [isFocused, setIsFocused] = useState<'title' | 'description' | null>(
+    null
+  );
+  const lastUpdateRef = useRef<FolderUpdateData>({ title, description });
 
-  const MAX_TITLE_LENGTH = 21;
-  const MAX_DESCRIPTION_LENGTH = 200;
+  const { pageId } = usePageStore();
+  const { mutate: updateFolder } = useUpdateFolder(pageId);
+
+  const updateFolderImmediately = (data: FolderUpdateData) => {
+    if (!folderId) return;
+
+    const updateData = {
+      baseRequest: { pageId, commandType: 'EDIT' },
+      folderId,
+      folderName: data.title,
+      folderDescription: data.description,
+    };
+
+    console.log('서버로 전송할 데이터:', updateData);
+
+    updateFolder(updateData, {
+      onSuccess: () => {
+        console.log('폴더 업데이트 성공:', data);
+      },
+      onError: (error) => {
+        console.error('폴더 업데이트 실패:', error);
+        setTitle(pageTitle ?? '');
+        setDescription(pageDescription ?? '');
+      },
+    });
+  };
+
+  const debouncedUpdate = useDebounce<FolderUpdateData>((data) => {
+    console.log('디바운스된 업데이트:', data);
+    lastUpdateRef.current = data;
+  }, 200);
+
+  // 초기 마운트 시에만 props로 상태 초기화
+  useEffect(() => {
+    console.log('초기 마운트 상태 초기화:', { pageTitle, pageDescription });
+    setTitle(pageTitle ?? '');
+    setDescription(pageDescription ?? '');
+    const newState = {
+      title: pageTitle ?? '',
+      description: pageDescription ?? '',
+    };
+    lastUpdateRef.current = newState;
+  }, [pageTitle, pageDescription]);
+
+  // 언마운트 시 마지막 상태 서버에 저장
+  useEffect(() => {
+    return () => {
+      console.log('언마운트 시 마지막 상태 저장:', lastUpdateRef.current);
+      updateFolderImmediately(lastUpdateRef.current);
+    };
+  }, []);
+
+  const handleBlur = () => {
+    console.log('포커스 아웃:', {
+      current: { title, description },
+    });
+
+    const currentState = { title, description };
+    lastUpdateRef.current = currentState;
+    updateFolderImmediately(currentState);
+  };
 
   return (
     <div className="mx-auto flex w-full max-w-[1180px] min-w-[328px] flex-col gap-[8px] px-[64px] py-[24px]">
       <div className="relative w-full">
         <input
           type="text"
-          value={pageTitle ?? ''}
-          // TODO: onChange 로직 변경 필요
+          value={title}
           onChange={(e) => {
-            if (e.target.value.length <= MAX_TITLE_LENGTH) {
-              setTitle(e.target.value);
+            const value = e.target.value;
+            if (value.length <= MAX_TITLE_LENGTH) {
+              setTitle(value);
+              debouncedUpdate({ title: value, description });
             }
           }}
-          // placeholder="제목을 입력하세요"
-          className="inline-block text-[24px] font-bold text-gray-100 outline-none"
+          onFocus={() => {
+            console.log('title input focus');
+            setIsFocused('title');
+          }}
+          onBlur={(e) => {
+            console.log('title input blur', e.target.value);
+            setIsFocused(null);
+            handleBlur();
+          }}
+          className={`inline-block text-[24px] font-bold outline-none ${
+            isFocused === 'title' ? 'text-gray-100' : 'text-gray-90'
+          }`}
         />
       </div>
       <div>
         <textarea
-          value={pageDescription ?? ''}
+          value={description}
           onChange={(e) => {
-            if (e.target.value.length <= MAX_DESCRIPTION_LENGTH) {
-              setDescription(e.target.value);
+            const value = e.target.value;
+            if (value.length <= MAX_DESCRIPTION_LENGTH) {
+              setDescription(value);
+              debouncedUpdate({ title, description: value });
             }
           }}
-          // placeholder="페이지에 대한 설명을 입력하세요. 디렉토리 소개글은 200자를 넘을 수 없습니다"
-          className="text-gray-70 max-h-[98px] w-full resize-none overflow-y-auto text-[16px] font-[400] outline-none"
+          onFocus={() => {
+            console.log('description textarea focus');
+            setIsFocused('description');
+          }}
+          onBlur={(e) => {
+            console.log('description textarea blur', e.target.value);
+            setIsFocused(null);
+            handleBlur();
+          }}
+          className={`max-h-[98px] w-full resize-none overflow-y-auto text-[16px] font-[400] outline-none ${
+            isFocused === 'description' ? 'text-gray-100' : 'text-gray-70'
+          }`}
         />
       </div>
     </div>

--- a/src/components/page-layout-ui/PersonalPageContentSection.tsx
+++ b/src/components/page-layout-ui/PersonalPageContentSection.tsx
@@ -69,7 +69,7 @@ export default function PersonalPageContentSection({
           if ('folderId' in item) {
             return (
               <FolderItem
-                key={item.orderIndex}
+                key={item.folderName}
                 isBookmark={item.isFavorite}
                 setIsBookmark={setIsBookmark}
                 item={{ id: item.folderId, title: item.folderName }}
@@ -79,14 +79,10 @@ export default function PersonalPageContentSection({
           } else if ('linkId' in item) {
             return (
               <LinkItem
-                key={item.orderIndex}
+                key={item.linkName}
                 isBookmark={item.isFavorite}
                 setIsBookmark={setIsBookmark}
-                item={{
-                  id: item.linkId,
-                  title: item.linkName,
-                  linkUrl: item.linkUrl,
-                }}
+                item={{ id: item.linkId, title: item.linkName }}
                 view={view}
               />
             );

--- a/src/components/page-layout-ui/PersonalPageContentSection.tsx
+++ b/src/components/page-layout-ui/PersonalPageContentSection.tsx
@@ -35,6 +35,8 @@ export default function PersonalPageContentSection({
     commandType: 'VIEW',
   });
 
+  console.log('선택한 페이지 데이터:', selectedPageQuery.data);
+
   useEffect(() => {
     setPageInfo(resolvedPageId, 'VIEW');
     setParentsFolderId(selectedPageQuery.data?.data.parentsFolderId);

--- a/src/components/page-layout-ui/SharedPageContentSection.tsx
+++ b/src/components/page-layout-ui/SharedPageContentSection.tsx
@@ -19,8 +19,12 @@ export default function SharedPageContentSection({
     setContextMenu({ x: e.clientX, y: e.clientY });
   };
 
-  const folderData = contentData?.directoryDetailRespons ?? [];
-  const linkData = contentData?.siteDetailResponses ?? [];
+  const folderData =
+    contentData?.directoryDetailRespons ??
+    contentData?.directoryDetailResponses ??
+    [];
+  const linkData =
+    contentData?.siteDetailResponses ?? contentData?.siteDetailResponses ?? [];
   const mergedList = [...folderData, ...linkData].sort(
     (a, b) => a.orderIndex - b.orderIndex
   );

--- a/src/components/page-layout-ui/SharedPageContentSection.tsx
+++ b/src/components/page-layout-ui/SharedPageContentSection.tsx
@@ -42,7 +42,7 @@ export default function SharedPageContentSection({
           if ('folderId' in item) {
             return (
               <FolderItem
-                key={item.orderIndex}
+                key={item.folderName}
                 isBookmark={item.isFavorite}
                 setIsBookmark={setIsBookmark}
                 item={{ id: item.folderId, title: item.folderName }}
@@ -52,7 +52,7 @@ export default function SharedPageContentSection({
           } else if ('linkId' in item) {
             return (
               <LinkItem
-                key={item.orderIndex}
+                key={item.linkName}
                 isBookmark={item.isFavorite}
                 setIsBookmark={setIsBookmark}
                 item={{

--- a/src/components/page-layout-ui/SharedPageContentSection.tsx
+++ b/src/components/page-layout-ui/SharedPageContentSection.tsx
@@ -76,6 +76,8 @@ export default function SharedPageContentSection({
             x={contextMenu.x}
             y={contextMenu.y}
             onClose={() => setContextMenu(null)}
+            onAddFolder={() => {}}
+            onAddLink={() => {}}
           />
         )}
       </div>

--- a/src/components/page-layout-ui/SharedPageContentSection.tsx
+++ b/src/components/page-layout-ui/SharedPageContentSection.tsx
@@ -7,6 +7,7 @@ import { PageContentSectionProps } from '@/types/pageItems';
 export default function SharedPageContentSection({
   view,
   contentData,
+  pageDescription,
 }: PageContentSectionProps) {
   const [isBookmark, setIsBookmark] = useState(false);
   const [contextMenu, setContextMenu] = useState<{
@@ -50,6 +51,7 @@ export default function SharedPageContentSection({
                 isBookmark={item.isFavorite}
                 setIsBookmark={setIsBookmark}
                 item={{ id: item.folderId, title: item.folderName }}
+                pageDescription={pageDescription}
                 view={view}
               />
             );

--- a/src/components/page-layout-ui/SharedPageContentSection.tsx
+++ b/src/components/page-layout-ui/SharedPageContentSection.tsx
@@ -56,7 +56,7 @@ export default function SharedPageContentSection({
                 isBookmark={item.isFavorite}
                 setIsBookmark={setIsBookmark}
                 item={{ id: item.folderId, title: item.folderName }}
-                pageDescription={pageDescription}
+                pageDescription={contentData?.pageDescription}
                 view={view}
               />
             );

--- a/src/hooks/mutations/useCreateFolder.ts
+++ b/src/hooks/mutations/useCreateFolder.ts
@@ -1,20 +1,56 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import {
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { createFolder } from '@/apis/folder-apis/createFolder';
 import { CreateFolderData } from '@/types/folders';
-import { queryClient } from '@/lib/queryClient';
 
 export function useCreateFolder(
   pageId: number,
   commandType: string,
-  options: UseMutationOptions<any, unknown, CreateFolderData>
+  options?: UseMutationOptions<any, unknown, CreateFolderData>
 ) {
+  const queryClient = useQueryClient();
+
   return useMutation({
-    mutationFn: createFolder,
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['folders', pageId, commandType],
-      });
-    },
     ...options,
+    mutationFn: createFolder,
+    onSuccess: async (response, variables, context) => {
+      console.log('폴더 생성 응답:', response);
+
+      // 현재 캐시된 데이터 확인
+      const currentData = queryClient.getQueryData([
+        'selectedPage',
+        pageId,
+        commandType,
+      ]);
+      console.log('현재 캐시된 데이터:', currentData);
+
+      // 쿼리 무효화 및 리페치
+      await queryClient.invalidateQueries({
+        queryKey: ['selectedPage', pageId, commandType],
+        refetchType: 'active',
+      });
+
+      // 무효화 후 캐시 상태 확인
+      const newData = queryClient.getQueryData([
+        'selectedPage',
+        pageId,
+        commandType,
+      ]);
+      console.log('무효화 후 캐시 데이터:', newData);
+
+      // 부모 컴포넌트의 onSuccess 콜백 실행
+      if (options?.onSuccess) {
+        options.onSuccess(response, variables, context);
+      }
+    },
+    onError: (error, variables, context) => {
+      console.error('폴더 생성 에러:', error);
+      if (options?.onError) {
+        options.onError(error, variables, context);
+      }
+    },
   });
 }

--- a/src/hooks/mutations/useCreateFolder.ts
+++ b/src/hooks/mutations/useCreateFolder.ts
@@ -1,12 +1,20 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { createFolder } from '@/apis/folder-apis/createFolder';
 import { CreateFolderData } from '@/types/folders';
+import { queryClient } from '@/lib/queryClient';
 
 export function useCreateFolder(
-  options?: UseMutationOptions<any, unknown, CreateFolderData>
+  pageId: number,
+  commandType: string,
+  options: UseMutationOptions<any, unknown, CreateFolderData>
 ) {
   return useMutation({
     mutationFn: createFolder,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['folders', pageId, commandType],
+      });
+    },
     ...options,
   });
 }

--- a/src/hooks/mutations/useCreateFolder.ts
+++ b/src/hooks/mutations/useCreateFolder.ts
@@ -17,31 +17,20 @@ export function useCreateFolder(
     ...options,
     mutationFn: createFolder,
     onSuccess: async (response, variables, context) => {
-      console.log('폴더 생성 응답:', response);
-
-      // 현재 캐시된 데이터 확인
-      const currentData = queryClient.getQueryData([
-        'selectedPage',
-        pageId,
-        commandType,
+      // 현재 페이지의 모든 관련 쿼리 무효화
+      await Promise.all([
+        // 일반 페이지 쿼리 무효화
+        queryClient.invalidateQueries({
+          queryKey: ['selectedPage', pageId, commandType],
+          refetchType: 'active',
+        }),
+        // 폴더 상세 페이지 쿼리 무효화 (모든 폴더 ID에 대해)
+        queryClient.invalidateQueries({
+          queryKey: ['folderDetails', pageId],
+          refetchType: 'active',
+        }),
       ]);
-      console.log('현재 캐시된 데이터:', currentData);
 
-      // 쿼리 무효화 및 리페치
-      await queryClient.invalidateQueries({
-        queryKey: ['selectedPage', pageId, commandType],
-        refetchType: 'active',
-      });
-
-      // 무효화 후 캐시 상태 확인
-      const newData = queryClient.getQueryData([
-        'selectedPage',
-        pageId,
-        commandType,
-      ]);
-      console.log('무효화 후 캐시 데이터:', newData);
-
-      // 부모 컴포넌트의 onSuccess 콜백 실행
       if (options?.onSuccess) {
         options.onSuccess(response, variables, context);
       }

--- a/src/hooks/mutations/useDeleteFolder.ts
+++ b/src/hooks/mutations/useDeleteFolder.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query';
+import deleteFolder from '@/apis/folder-apis/deleteFolder';
+import { queryClient } from '@/lib/queryClient';
+
+export default function useDeleteFolder(pageId: number, commandType: string) {
+  return useMutation({
+    mutationFn: deleteFolder,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['folders', pageId, commandType],
+      });
+    },
+  });
+}

--- a/src/hooks/mutations/useDeleteFolder.ts
+++ b/src/hooks/mutations/useDeleteFolder.ts
@@ -2,7 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import deleteFolder from '@/apis/folder-apis/deleteFolder';
 import { queryClient } from '@/lib/queryClient';
 
-export default function useDeleteFolder(pageId: number, commandType: string) {
+export default function useDeleteFolder(pageId: number, commandType?: string) {
   return useMutation({
     mutationFn: deleteFolder,
     onSuccess: () => {

--- a/src/hooks/mutations/useDeleteFolder.ts
+++ b/src/hooks/mutations/useDeleteFolder.ts
@@ -1,14 +1,35 @@
-import { useMutation } from '@tanstack/react-query';
+import {
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
 import deleteFolder from '@/apis/folder-apis/deleteFolder';
-import { queryClient } from '@/lib/queryClient';
+import { DeleteFolderData } from '@/types/folders';
 
-export default function useDeleteFolder(pageId: number, commandType?: string) {
+export default function useDeleteFolder(
+  pageId: number,
+  options?: UseMutationOptions<any, unknown, DeleteFolderData>
+) {
+  const queryClient = useQueryClient();
+
   return useMutation({
+    ...options,
     mutationFn: deleteFolder,
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['folders', pageId, commandType],
+    onSuccess: async (response, variables, context) => {
+      await queryClient.invalidateQueries({
+        queryKey: ['selectedPage', pageId, 'VIEW'],
+        refetchType: 'active',
       });
+
+      if (options?.onSuccess) {
+        options.onSuccess(response, variables, context);
+      }
+    },
+    onError: (error, variables, context) => {
+      console.error('폴더 삭제 에러:', error);
+      if (options?.onError) {
+        options.onError(error, variables, context);
+      }
     },
   });
 }

--- a/src/hooks/mutations/useUpdateFolder.ts
+++ b/src/hooks/mutations/useUpdateFolder.ts
@@ -1,0 +1,40 @@
+import {
+  useMutation,
+  useQueryClient,
+  UseMutationOptions,
+} from '@tanstack/react-query';
+import updateFolder from '@/apis/folder-apis/updateFolder';
+import { UpdateFolderData } from '@/types/folders';
+
+export default function useUpdateFolder(
+  pageId: number,
+  options?: UseMutationOptions<any, unknown, UpdateFolderData>
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateFolder,
+    onSuccess: async (response, variables, context) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['selectedPage', pageId, 'VIEW'],
+          refetchType: 'active',
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['folderDetails', pageId],
+          refetchType: 'active',
+        }),
+      ]);
+
+      if (options?.onSuccess) {
+        options.onSuccess(response, variables, context);
+      }
+    },
+    onError: (error, variables, context) => {
+      console.error('폴더 생성 에러:', error);
+      if (options?.onError) {
+        options.onError(error, variables, context);
+      }
+    },
+  });
+}

--- a/src/hooks/mutations/useUpdateFolder.ts
+++ b/src/hooks/mutations/useUpdateFolder.ts
@@ -13,6 +13,7 @@ export default function useUpdateFolder(
   const queryClient = useQueryClient();
 
   return useMutation({
+    ...options,
     mutationFn: updateFolder,
     onSuccess: async (response, variables, context) => {
       await Promise.all([
@@ -31,7 +32,6 @@ export default function useUpdateFolder(
       }
     },
     onError: (error, variables, context) => {
-      console.error('폴더 생성 에러:', error);
       if (options?.onError) {
         options.onError(error, variables, context);
       }

--- a/src/hooks/mutations/useUpdateFolder.ts
+++ b/src/hooks/mutations/useUpdateFolder.ts
@@ -16,22 +16,45 @@ export default function useUpdateFolder(
     ...options,
     mutationFn: updateFolder,
     onSuccess: async (response, variables, context) => {
+      // 모든 commandType에 대해 캐시 무효화
+      const commandTypes = ['VIEW', 'EDIT'];
+
       await Promise.all([
+        // 페이지 쿼리 무효화
         queryClient.invalidateQueries({
           queryKey: ['selectedPage', pageId, 'VIEW'],
           refetchType: 'active',
         }),
-        queryClient.invalidateQueries({
-          queryKey: ['folderDetails', pageId],
-          refetchType: 'active',
-        }),
+        // 폴더 상세 정보 쿼리 무효화 (모든 commandType에 대해)
+        ...commandTypes.flatMap((commandType) => [
+          queryClient.invalidateQueries({
+            queryKey: [
+              'folderDetails',
+              pageId,
+              variables.folderId,
+              commandType,
+            ],
+            refetchType: 'active',
+          }),
+          queryClient.invalidateQueries({
+            queryKey: ['folderDetails', pageId],
+            refetchType: 'active',
+          }),
+        ]),
       ]);
+
+      console.log('캐시 무효화 완료:', {
+        pageId,
+        folderId: variables.folderId,
+        commandTypes,
+      });
 
       if (options?.onSuccess) {
         options.onSuccess(response, variables, context);
       }
     },
     onError: (error, variables, context) => {
+      console.error('폴더 업데이트 에러:', error);
       if (options?.onError) {
         options.onError(error, variables, context);
       }

--- a/src/hooks/queries/useFetchFolderDetails.ts
+++ b/src/hooks/queries/useFetchFolderDetails.ts
@@ -1,0 +1,16 @@
+import fetchFolderDetails from '@/apis/folder-apis/fetchFolderDetails';
+import { FetchFolderDetailsProps } from '@/types/folders';
+import { useQuery } from '@tanstack/react-query';
+
+export default function useFetchFolderDetails(data: FetchFolderDetailsProps) {
+  return useQuery({
+    queryKey: [
+      'folderDetails',
+      data.pageId,
+      data.commandType,
+      data.folderId,
+      data.sortType,
+    ],
+    queryFn: () => fetchFolderDetails(data),
+  });
+}

--- a/src/hooks/queries/useFetchFolderDetails.ts
+++ b/src/hooks/queries/useFetchFolderDetails.ts
@@ -4,13 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 
 export default function useFetchFolderDetails(data: FetchFolderDetailsProps) {
   return useQuery({
-    queryKey: [
-      'folderDetails',
-      data.pageId,
-      data.commandType,
-      data.folderId,
-      data.sortType,
-    ],
+    queryKey: ['folderDetails', data.pageId, data.folderId, data.commandType],
     queryFn: () => fetchFolderDetails(data),
   });
 }

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -2,9 +2,12 @@ import { useEffect } from 'react';
 
 export function useClickOutside<T extends HTMLElement>(
   ref: React.RefObject<T>,
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>,
+  enabled: boolean = true
 ) {
   useEffect(() => {
+    if (!enabled) return;
+
     if (!ref.current) return;
 
     const handleClickOutside = (e: MouseEvent) => {
@@ -18,7 +21,7 @@ export function useClickOutside<T extends HTMLElement>(
     return () => {
       document.removeEventListener('click', handleClickOutside, true);
     };
-  }, [ref, setIsOpen]);
+  }, [ref, setIsOpen, enabled]);
 }
 
 /* 

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,15 +1,23 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useRef } from 'react';
 
-export function useDebounce<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState(value);
+type DebouncedFunction<T> = (value: T) => void;
 
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedValue(value);
-    }, delay);
+export function useDebounce<T>(
+  callback: (value: T) => void,
+  delay: number
+): DebouncedFunction<T> {
+  const timeoutRef = useRef<NodeJS.Timeout>();
 
-    return () => clearTimeout(handler);
-  }, [value, delay]);
+  return useCallback(
+    (value: T) => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
 
-  return debouncedValue;
+      timeoutRef.current = setTimeout(() => {
+        callback(value);
+      }, delay);
+    },
+    [callback, delay]
+  );
 }

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,23 @@
+import { useCallback, useRef } from 'react';
+
+type DebouncedFunction<T> = (value: T) => void;
+
+export function useDebounce<T>(
+  callback: (value: T) => void,
+  delay: number
+): DebouncedFunction<T> {
+  const timeoutRef = useRef<NodeJS.Timeout>();
+
+  return useCallback(
+    (value: T) => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      timeoutRef.current = setTimeout(() => {
+        callback(value);
+      }, delay);
+    },
+    [callback, delay]
+  );
+}

--- a/src/pages/FolderDetailPage.tsx
+++ b/src/pages/FolderDetailPage.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { useMobile } from '@/hooks/useMobile';
+import SharedPageContentSection from '@/components/page-layout-ui/SharedPageContentSection';
+import PageHeaderSection from '@/components/page-layout-ui/PageHeaderSection';
+import PageControllerSection from '@/components/page-layout-ui/PageControllerSection';
+import useFetchFolderDetails from '@/hooks/queries/useFetchFolderDetails';
+import { usePageStore } from '@/stores/pageStore';
+import { useParams } from 'react-router-dom';
+
+export default function FolderDetailPage() {
+  const [view, setView] = useState<'grid' | 'list'>('grid');
+  const { pageId } = usePageStore();
+  const isMobile = useMobile();
+  const { folderId } = useParams();
+
+  useEffect(() => {
+    if (isMobile) {
+      setView('list');
+    }
+  }, [isMobile]);
+
+  const requestParams = {
+    pageId,
+    commandType: 'VIEW',
+    folderId: Number(folderId),
+    sortType: 'BASIC',
+  };
+
+  console.log('폴더 상세 요청 params:', requestParams);
+
+  const folderDetailsQuery = useFetchFolderDetails(requestParams);
+
+  console.log('폴더상세 페이지 정보', folderDetailsQuery.data);
+
+  return (
+    <div className="flex h-screen flex-col">
+      {/* HEADER SECTION*/}
+      <PageHeaderSection
+        pageTitle={folderDetailsQuery.data?.data.targetFolderName}
+        pageDescription={folderDetailsQuery.data?.data.targetFolderDescription}
+      />
+
+      {/* Boundary line */}
+      <div className="border-b-gray-30 mb-[40px] w-full border-b" />
+
+      {/* CONTROLLER SECTION*/}
+      <PageControllerSection view={view} setView={setView} />
+
+      {/*CONTENT SECTION*/}
+      <SharedPageContentSection
+        view={view}
+        contentData={folderDetailsQuery.data?.data}
+      />
+    </div>
+  );
+}

--- a/src/pages/FolderDetailPage.tsx
+++ b/src/pages/FolderDetailPage.tsx
@@ -4,12 +4,15 @@ import SharedPageContentSection from '@/components/page-layout-ui/SharedPageCont
 import PageHeaderSection from '@/components/page-layout-ui/PageHeaderSection';
 import PageControllerSection from '@/components/page-layout-ui/PageControllerSection';
 import useFetchFolderDetails from '@/hooks/queries/useFetchFolderDetails';
-import { usePageStore } from '@/stores/pageStore';
+import { usePageStore, useParentsFolderIdStore } from '@/stores/pageStore';
 import { useParams } from 'react-router-dom';
 
 export default function FolderDetailPage() {
   const [view, setView] = useState<'grid' | 'list'>('grid');
+
   const { pageId } = usePageStore();
+  const { setParentsFolderId } = useParentsFolderIdStore();
+
   const isMobile = useMobile();
   const { folderId } = useParams();
 
@@ -27,10 +30,13 @@ export default function FolderDetailPage() {
   };
 
   console.log('폴더 상세 요청 params:', requestParams);
-
   const folderDetailsQuery = useFetchFolderDetails(requestParams);
 
-  console.log('폴더상세 페이지 정보', folderDetailsQuery.data);
+  useEffect(() => {
+    setParentsFolderId(folderDetailsQuery.data?.data.targetFolderId);
+  }, [folderDetailsQuery.data, setParentsFolderId]);
+
+  console.log('폴더상세 페이지 정보', folderDetailsQuery.data?.data);
 
   return (
     <div className="flex h-screen flex-col">

--- a/src/pages/FolderDetailPage.tsx
+++ b/src/pages/FolderDetailPage.tsx
@@ -44,6 +44,7 @@ export default function FolderDetailPage() {
       <PageHeaderSection
         pageTitle={folderDetailsQuery.data?.data.targetFolderName}
         pageDescription={folderDetailsQuery.data?.data.targetFolderDescription}
+        folderId={folderDetailsQuery.data?.data.targetFolderId}
       />
 
       {/* Boundary line */}

--- a/src/pages/PersonalPage.tsx
+++ b/src/pages/PersonalPage.tsx
@@ -45,6 +45,7 @@ export default function PersonalPage() {
       <PageHeaderSection
         pageTitle={pageDetails?.pageTitle}
         pageDescription={pageDetails?.pageDescription}
+        folderId={pageDetails?.rootFolderId}
       />
 
       {/* Boundary line */}

--- a/src/pages/SharedPage.tsx
+++ b/src/pages/SharedPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams, Outlet } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useMobile } from '@/hooks/useMobile';
 import { useFetchSelectedPage } from '@/hooks/queries/useFetchSelectedPage';
 import { usePageStore, useParentsFolderIdStore } from '@/stores/pageStore';

--- a/src/pages/SharedPage.tsx
+++ b/src/pages/SharedPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Outlet } from 'react-router-dom';
 import { useMobile } from '@/hooks/useMobile';
 import { useFetchSelectedPage } from '@/hooks/queries/useFetchSelectedPage';
 import { usePageStore, useParentsFolderIdStore } from '@/stores/pageStore';

--- a/src/pages/SharedPage.tsx
+++ b/src/pages/SharedPage.tsx
@@ -77,6 +77,7 @@ export default function SharedPage() {
       <PageHeaderSection
         pageTitle={selectedPageQuery.data?.data.pageTitle}
         pageDescription={selectedPageQuery.data?.data.pageDescription}
+        folderId={selectedPageQuery.data?.data.rootFolderId}
       />
 
       {/* Boundary line */}

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -9,7 +9,7 @@ import { ProtectedRoute } from './guards/ProtectedRoute';
 import PersonalPage from '@/pages/PersonalPage';
 import BookmarkPage from '@/pages/BookmarkPage';
 import SharedPage from '@/pages/SharedPage';
-
+import FolderDetailPage from '@/pages/FolderDetailPage';
 const router = createBrowserRouter([
   {
     element: <Layout />,
@@ -20,12 +20,18 @@ const router = createBrowserRouter([
         children: [
           { path: '/', element: <PersonalPage /> },
           { path: '/personal', element: <PersonalPage /> },
+          { path: '/personal/folder/:folderId', element: <FolderDetailPage /> },
           { path: '/bookmarks', element: <BookmarkPage /> },
-          { path: '/shared/:pageId', element: <SharedPage /> },
+          {
+            path: '/shared/:pageId',
+            element: <SharedPage />,
+          },
+          {
+            path: '/shared/:pageId/folder/:folderId',
+            element: <FolderDetailPage />,
+          },
           // 이후 디렉토리에 따른 경로
-          // { path: '/personal/folder/:folderId', element: <PersonalPage /> },
-          // {
-          //   path: '/personal/bookmarks/folder/:folderId',
+          // { path: '/bookmarks/folder/:folderId',
           //   element: <BookmarkPage />,
           // },
           // {

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -20,7 +20,7 @@ const router = createBrowserRouter([
         children: [
           { path: '/', element: <PersonalPage /> },
           { path: '/personal', element: <PersonalPage /> },
-          { path: '/personal/folder/:folderId', element: <FolderDetailPage /> },
+          { path: '/folder/:folderId', element: <FolderDetailPage /> },
           { path: '/bookmarks', element: <BookmarkPage /> },
           {
             path: '/shared/:pageId',

--- a/src/stores/linkActionStore.ts
+++ b/src/stores/linkActionStore.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand';
 
 type LinkActionStore = {
-  deleteLink: (id: string) => void;
-  setDeleteLink: (fn: (id: string) => void) => void;
+  deleteLink: (id: number) => void;
+  setDeleteLink: (fn: (id: number) => void) => void;
 };
 
 export const useLinkActionStore = create<LinkActionStore>((set) => ({

--- a/src/types/folders.ts
+++ b/src/types/folders.ts
@@ -7,3 +7,18 @@ export type CreateFolderData = {
   parentFolderId: number;
   folderDescription: string;
 };
+
+export type DeleteFolderData = {
+  baseRequest: {
+    pageId: number;
+    commandType: string;
+  };
+  folderId: number;
+};
+
+export interface FetchFolderDetailsProps {
+  pageId: number;
+  commandType: string;
+  folderId: number;
+  sortType: string;
+}

--- a/src/types/folders.ts
+++ b/src/types/folders.ts
@@ -8,6 +8,16 @@ export type CreateFolderData = {
   folderDescription: string;
 };
 
+export type UpdateFolderData = {
+  baseRequest: {
+    pageId: number;
+    commandType: string;
+  };
+  folderName: string;
+  folderId: number;
+  folderDescription?: string;
+};
+
 export type DeleteFolderData = {
   baseRequest: {
     pageId: number;

--- a/src/types/pageItems.ts
+++ b/src/types/pageItems.ts
@@ -2,11 +2,11 @@ export type ViewType = 'grid' | 'list';
 
 export interface ContentData {
   folders?: Array<{
-    id: string;
+    id: number;
     title: string;
   }>;
   links?: Array<{
-    id: string;
+    id: number;
     title: string;
     linkUrl?: string;
   }>;
@@ -14,7 +14,7 @@ export interface ContentData {
 
 export interface PageItemProps {
   item: {
-    id: string;
+    id: number;
     title: string;
     linkUrl?: string;
   };

--- a/src/types/pageItems.ts
+++ b/src/types/pageItems.ts
@@ -21,11 +21,13 @@ export interface PageItemProps {
   isBookmark: boolean;
   setIsBookmark: React.Dispatch<React.SetStateAction<boolean>>;
   view: ViewType;
+  pageDescription?: string;
 }
 
 export interface PageContentSectionProps {
   view: ViewType;
   contentData?: any;
+  pageDescription?: string;
 }
 
 export interface PageControllerSectionProps extends PageContentSectionProps {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

### #️⃣ 이슈 번호

> close #90 

## 📋 작업 내용

- 폴더 관련 crud 구현
- 폴더 생성시 즉시 렌더링을 위한 queryKey 수정 (당장에 구현을 위해 캐싱 성능을 신경쓰지 않는 임시 키입니다)
- dropdown 분기를 위해 type link, folder 지정
- debounce, onblur, unmount를 활용한 폴더 제목, 설명 수정 추가 (이후 커스텀 훅으로 만들어 수정완료 버튼을 제거하고, 해당 훅을 사용하면 좋을 듯 합니다.)
ㄴ 해당 부분에 대해선 페이지에선 적용이 되지 않아 추후 확정되는대로 말씀드릴게요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 폴더 상세 페이지 및 폴더 편집, 삭제, 업데이트 기능이 추가되었습니다.
  - 폴더 더블 클릭 시 상세 페이지로 이동할 수 있습니다.
  - 폴더 제목 및 설명을 실시간으로 수정하고 서버와 동기화할 수 있습니다.

- **버그 수정**
  - 폴더 및 링크 관련 ID 타입이 string에서 number로 통일되어 일관성이 향상되었습니다.

- **UI/UX 개선**
  - 드롭다운, 모달 등에서 폴더와 링크 모두에 대해 개선된 편집 및 삭제 인터페이스를 제공합니다.
  - 버튼에 커서 포인터 스타일이 적용되어 상호작용성이 향상되었습니다.

- **기타**
  - 폴더 관련 API 및 커스텀 훅이 추가되어 폴더 데이터의 생성, 수정, 삭제, 상세 조회가 가능합니다.
  - 라우터에 폴더 상세 경로가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->