### PR TITLE
refact: dropdowninline 관련 로직 리팩토링 및 외부 클릭 감지 훅 분리

### DIFF
--- a/src/components/common-ui/DropDownInline.tsx
+++ b/src/components/common-ui/DropDownInline.tsx
@@ -2,15 +2,15 @@ import { useRef, useState } from 'react';
 import Transfer from '@/assets/common-ui-assets/Transfer.svg?react';
 import Copy from '@/assets/common-ui-assets/Copy.svg?react';
 import Delete from '@/assets/common-ui-assets/Delete.svg?react';
-import { useClickOutside } from '@/hooks/useClickOutside';
-import { useLinkActionStore } from '@/stores/linkActionStore';
 import { useUpdateLink } from '@/hooks/mutations/useUpdateLink';
 import { usePageStore } from '@/stores/pageStore';
 import { useModalStore } from '@/stores/modalStore';
 import FolderTransferModal from '../modal/folder/FolderTransferModal';
 import { useTransferActionStore } from '@/stores/transferActionStore';
 import DeleteFolderModal from '../modal/folder/DeleteFolderModal';
+import DeleteLinkModal from '../modal/link/DeleteLinkModal';
 import useUpdateFolder from '@/hooks/mutations/useUpdateFolder';
+import { useClickOutsideMultiple } from '@/hooks/useClickOutsideMultiple';
 
 type DropDownInlineProps = {
   id: number;
@@ -35,17 +35,13 @@ const DropDownInline = ({
   setIsDropDownInline,
   className,
 }: DropDownInlineProps) => {
-  console.log('DropDownInline 렌더됨?', id, initialTitle);
-
   const [title, setTitle] = useState(initialTitle);
-
   const [link, setLink] = useState(initialLink);
 
-  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isFolderDeleteOpen, setIsFolderDeleteOpen] = useState(false);
+  const [isLinkDeleteOpen, setIsLinkDeleteOpen] = useState(false);
 
-  const dropdownRef = useRef<HTMLDivElement>(null);
   const { openTransferFolderModal } = useModalStore();
-  const deleteLink = useLinkActionStore((state) => state.deleteLink);
 
   const { isTransferFolderModalOpen, closeTransferFolderModal } =
     useModalStore();
@@ -57,7 +53,7 @@ const DropDownInline = ({
 
   const pageId = usePageStore((state) => state.pageId);
 
-  const { mutate } = useUpdateLink();
+  const { mutate: mutateLink } = useUpdateLink();
   const { mutate: mutateFolder } = useUpdateFolder(pageId);
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -72,20 +68,34 @@ const DropDownInline = ({
     onLinkChange?.(id, value);
   };
 
-  const modalRef = useRef<HTMLDivElement>(null);
-
-  const handleDeleteOpen = () => {
-    setIsDeleteOpen(true);
+  const handleFolderDeleteOpen = () => {
+    setIsFolderDeleteOpen(true);
   };
 
-  useClickOutside(dropdownRef, setIsDropDownInline, !isDeleteOpen);
+  const handleLinkDeleteOpen = () => {
+    setIsLinkDeleteOpen(true);
+  };
+
+  const isAnyModalOpen =
+    isFolderDeleteOpen || isLinkDeleteOpen || isTransferFolderModalOpen;
+
+  const dropdownRef = useRef(null);
+  const folderModalRef = useRef(null);
+  const linkModalRef = useRef(null);
+  const transferModalRef = useRef(null);
+
+  useClickOutsideMultiple(
+    [dropdownRef, folderModalRef, linkModalRef, transferModalRef],
+    setIsDropDownInline,
+    !isAnyModalOpen
+  );
 
   return (
     <div
       ref={dropdownRef}
       className={`border-gray-30 focus:bg-gray-30 focus:border-gray-30 bg-gray-0 inline-flex w-[214px] flex-col rounded-[10px] border p-[8px] text-[14px] font-[600] shadow ${className}`}
     >
-      {type === 'directory' && (
+      {type === 'folder' && (
         <div className="flex flex-col">
           <input
             value={title}
@@ -137,16 +147,17 @@ const DropDownInline = ({
             <Copy width={18} height={18} /> 복사하기
           </button>
           <button
-            onClick={handleDeleteOpen}
+            onClick={handleFolderDeleteOpen}
             className="text-status-danger flex cursor-pointer items-center gap-[10px] px-[8px] py-[11px]"
           >
             <Delete width={18} height={18} /> 삭제하기
           </button>
 
-          {isDeleteOpen && (
+          {isFolderDeleteOpen && (
             <DeleteFolderModal
-              isOpen={isDeleteOpen}
-              onClose={() => setIsDeleteOpen(false)}
+              ref={folderModalRef}
+              isOpen={isFolderDeleteOpen}
+              onClose={() => setIsFolderDeleteOpen(false)}
               folderId={id}
               pageId={pageId}
             />
@@ -173,7 +184,7 @@ const DropDownInline = ({
           {isModifiedLink && (
             <button
               onClick={() => {
-                mutate(
+                mutateLink(
                   {
                     baseRequest: {
                       pageId,
@@ -206,15 +217,24 @@ const DropDownInline = ({
             <Transfer width={18} height={18} /> 전송하기
           </button>
           <button
-            onClick={() => deleteLink(id)}
+            onClick={() => handleLinkDeleteOpen()}
             className="text-status-danger flex cursor-pointer items-center gap-[10px] p-[12px]"
           >
             <Delete width={18} height={18} /> 삭제하기
           </button>
+          {isLinkDeleteOpen && (
+            <DeleteLinkModal
+              ref={linkModalRef}
+              isOpen={isLinkDeleteOpen}
+              onClose={() => setIsLinkDeleteOpen(false)}
+              linkId={id}
+              pageId={pageId}
+            />
+          )}
         </div>
       )}
       <FolderTransferModal
-        ref={modalRef}
+        ref={transferModalRef}
         isOpen={isTransferFolderModalOpen}
         onClose={closeTransferFolderModal}
         directoryId={Number(id)}

--- a/src/components/common-ui/Modal.tsx
+++ b/src/components/common-ui/Modal.tsx
@@ -1,4 +1,11 @@
-import React, { createContext, useContext, useEffect, useRef } from 'react';
+import React, {
+  createContext,
+  forwardRef,
+  useContext,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { cn } from '@/utils/cn';
 
@@ -12,18 +19,18 @@ const ModalContext = createContext<{
 });
 
 // 기본 모달 컴포넌트
-const Modal = ({
-  children,
-  isOpen,
-  onClose,
-  className,
-}: {
-  children: React.ReactNode;
-  isOpen: boolean;
-  onClose: () => void;
-  className?: string;
-}) => {
+const BaseModal = forwardRef<
+  HTMLDivElement,
+  {
+    children: React.ReactNode;
+    isOpen: boolean;
+    onClose: () => void;
+    className?: string;
+  }
+>(({ children, isOpen, onClose, className }, ref) => {
   const modalRef = useRef<HTMLDivElement>(null);
+
+  useImperativeHandle(ref, () => modalRef.current!, []);
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
@@ -33,7 +40,6 @@ const Modal = ({
     };
 
     document.addEventListener('click', handleClick, true);
-
     return () => document.removeEventListener('click', handleClick, true);
   }, [onClose]);
 
@@ -55,7 +61,7 @@ const Modal = ({
     </ModalContext.Provider>,
     document.body
   );
-};
+});
 
 // 헤더 컴포넌트
 const Header = ({
@@ -164,10 +170,12 @@ const CancelButton = ({
   );
 };
 
-Modal.Header = Header;
-Modal.Body = Body;
-Modal.Footer = Footer;
-Modal.ConfirmButton = ConfirmButton;
-Modal.CancelButton = CancelButton;
+const Modal = Object.assign(BaseModal, {
+  Header,
+  Body,
+  Footer,
+  ConfirmButton,
+  CancelButton,
+});
 
 export default Modal;

--- a/src/components/modal/folder/DeleteFolderModal.tsx
+++ b/src/components/modal/folder/DeleteFolderModal.tsx
@@ -1,18 +1,17 @@
 import Modal from '@/components/common-ui/Modal';
 import Status from '@/assets/common-ui-assets/Status.svg?react';
 import useDeleteFolder from '@/hooks/mutations/useDeleteFolder';
+import { forwardRef } from 'react';
 
-const DeleteFolderModal = ({
-  isOpen,
-  onClose,
-  folderId,
-  pageId,
-}: {
-  isOpen: boolean;
-  onClose: () => void;
-  folderId: number;
-  pageId: number;
-}) => {
+const DeleteFolderModal = forwardRef<
+  HTMLDivElement,
+  {
+    isOpen: boolean;
+    onClose: () => void;
+    folderId: number;
+    pageId: number;
+  }
+>(({ isOpen, onClose, folderId, pageId }, ref) => {
   const { mutate: deleteFolder } = useDeleteFolder(pageId);
 
   const handleDelete = () => {
@@ -29,7 +28,12 @@ const DeleteFolderModal = ({
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} className="p-4 md:max-w-[544px]">
+    <Modal
+      ref={ref}
+      isOpen={isOpen}
+      onClose={onClose}
+      className="p-4 md:max-w-[544px]"
+    >
       <Modal.Header className="border-none text-[22px] font-bold">
         <div className="flex items-center">
           <Status className="mr-[10px] py-[2.5px]" />
@@ -46,6 +50,6 @@ const DeleteFolderModal = ({
       </Modal.Footer>
     </Modal>
   );
-};
+});
 
 export default DeleteFolderModal;

--- a/src/components/modal/folder/FolderTransferModal.tsx
+++ b/src/components/modal/folder/FolderTransferModal.tsx
@@ -41,42 +41,40 @@ const FolderTransferModal = forwardRef<HTMLDivElement, Props>((props, ref) => {
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
-      <div ref={ref}>
-        <Modal.Header>폴더 전송</Modal.Header>
-        <Modal.Body className="py-4">
-          <div>
-            <div className="text-gray-90 mb-4 flex items-center px-[8px] py-[11px] text-sm font-semibold">
-              <FolderItemIcon className="mr-[10px] h-[18px] w-[18px]" />
-              {folderName}
-            </div>
-
-            <div>
-              <Input
-                label="받는 분 이메일"
-                placeholder="받는 분의 이메일 주소를 입력해 주세요"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                isModal={true}
-                inputSize="medium"
-                containerClassName="w-full"
-                labelClassName="font-bold leading-[140%]"
-              />
-            </div>
+    <Modal isOpen={isOpen} onClose={onClose} ref={ref}>
+      <Modal.Header>폴더 전송</Modal.Header>
+      <Modal.Body className="py-4">
+        <div>
+          <div className="text-gray-90 mb-4 flex items-center px-[8px] py-[11px] text-sm font-semibold">
+            <FolderItemIcon className="mr-[10px] h-[18px] w-[18px]" />
+            {folderName}
           </div>
-        </Modal.Body>
 
-        <Modal.Footer className="pt-0">
-          <Modal.CancelButton onClick={() => setEmail('')} />
-          <Modal.ConfirmButton
-            onClick={handleSubmit}
-            disabled={!email || isSubmitting}
-            variant={email ? 'primary' : 'default'}
-          >
-            {isSubmitting ? '전송 중...' : '전송'}
-          </Modal.ConfirmButton>
-        </Modal.Footer>
-      </div>
+          <div>
+            <Input
+              label="받는 분 이메일"
+              placeholder="받는 분의 이메일 주소를 입력해 주세요"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              isModal={true}
+              inputSize="medium"
+              containerClassName="w-full"
+              labelClassName="font-bold leading-[140%]"
+            />
+          </div>
+        </div>
+      </Modal.Body>
+
+      <Modal.Footer className="pt-0">
+        <Modal.CancelButton onClick={() => setEmail('')} />
+        <Modal.ConfirmButton
+          onClick={handleSubmit}
+          disabled={!email || isSubmitting}
+          variant={email ? 'primary' : 'default'}
+        >
+          {isSubmitting ? '전송 중...' : '전송'}
+        </Modal.ConfirmButton>
+      </Modal.Footer>
     </Modal>
   );
 });

--- a/src/components/modal/link/DeleteLinkModal.tsx
+++ b/src/components/modal/link/DeleteLinkModal.tsx
@@ -1,63 +1,57 @@
-import { useState } from 'react';
+import { forwardRef } from 'react';
 import Modal from '@/components/common-ui/Modal';
 import Status from '@/assets/common-ui-assets/Status.svg?react';
+import { useDeleteLink } from '@/hooks/mutations/useDeleteLink';
+import { DeleteLinkData } from '@/types/links';
 
-const DeleteLinkModal = ({
-  isOpen,
-  onClose,
-  onSubmit,
-  linkId,
-}: {
+type Props = {
   isOpen: boolean;
   onClose: () => void;
-  linkId: number | null;
-  onSubmit: (linkId: null | number) => Promise<void>;
-}) => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const handleSubmit = async (linkId: number | null) => {
-    if (linkId === null) {
-      console.error('삭제할 링크 ID가 없습니다.');
-      return;
-    }
-
-    setIsSubmitting(true);
-
-    try {
-      console.log('삭제할 링크 ID:', linkId);
-      await onSubmit(linkId);
-      onClose();
-    } catch (error) {
-      console.error('링크 삭제 오류:', error);
-      // Todo 에러 로직 추가 필요
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <Modal isOpen={isOpen} onClose={onClose} className="p-4 md:max-w-[544px]">
-      <Modal.Header className="border-none text-[22px] font-bold">
-        <div className="flex items-center">
-          <Status className="mr-[10px] py-[2.5px]" />
-          링크 삭제
-        </div>
-        <p className="text-gray-90 pl-9 text-base font-normal">
-          삭제하면 복구할 수 없습니다
-        </p>
-      </Modal.Header>
-
-      <Modal.Footer className="pt-0">
-        <Modal.CancelButton />
-        <Modal.ConfirmButton
-          onClick={() => handleSubmit(linkId)}
-          disabled={isSubmitting}
-        >
-          삭제
-        </Modal.ConfirmButton>
-      </Modal.Footer>
-    </Modal>
-  );
+  linkId: number;
+  pageId: number;
 };
+
+const DeleteLinkModal = forwardRef<HTMLDivElement, Props>(
+  ({ isOpen, onClose, linkId, pageId }, ref) => {
+    const { mutate: deleteLink } = useDeleteLink();
+
+    const handleDelete = () => {
+      const requestBody: DeleteLinkData = {
+        baseRequest: {
+          pageId,
+          commandType: 'EDIT',
+        },
+        linkId,
+      };
+      console.log('링크 삭제 요청 데이터', requestBody);
+      deleteLink(requestBody);
+      onClose();
+    };
+
+    return (
+      <Modal
+        ref={ref}
+        isOpen={isOpen}
+        onClose={onClose}
+        className="p-4 md:max-w-[544px]"
+      >
+        <Modal.Header className="border-none text-[22px] font-bold">
+          <div className="flex items-center">
+            <Status className="mr-[10px] py-[2.5px]" />
+            링크 삭제
+          </div>
+          <p className="text-gray-90 pl-9 text-base font-normal">
+            삭제하면 복구할 수 없습니다
+          </p>
+        </Modal.Header>
+
+        <Modal.Footer className="pt-0">
+          <Modal.CancelButton />
+          <Modal.ConfirmButton onClick={handleDelete}>삭제</Modal.ConfirmButton>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+);
 
 export default DeleteLinkModal;

--- a/src/components/modal/link/DeleteLinkModal.tsx
+++ b/src/components/modal/link/DeleteLinkModal.tsx
@@ -13,7 +13,7 @@ type Props = {
 
 const DeleteLinkModal = forwardRef<HTMLDivElement, Props>(
   ({ isOpen, onClose, linkId, pageId }, ref) => {
-    const { mutate: deleteLink } = useDeleteLink();
+    const { mutate: deleteLink, isPending } = useDeleteLink();
 
     const handleDelete = () => {
       const requestBody: DeleteLinkData = {
@@ -23,9 +23,16 @@ const DeleteLinkModal = forwardRef<HTMLDivElement, Props>(
         },
         linkId,
       };
-      console.log('링크 삭제 요청 데이터', requestBody);
-      deleteLink(requestBody);
-      onClose();
+
+      deleteLink(requestBody, {
+        onSuccess: () => {
+          onClose();
+        },
+        onError: (error) => {
+          console.error('링크 삭제 실패:', error);
+          // TODO: 사용자에게 에러 메시지 표시
+        },
+      });
     };
 
     return (
@@ -47,7 +54,9 @@ const DeleteLinkModal = forwardRef<HTMLDivElement, Props>(
 
         <Modal.Footer className="pt-0">
           <Modal.CancelButton />
-          <Modal.ConfirmButton onClick={handleDelete}>삭제</Modal.ConfirmButton>
+          <Modal.ConfirmButton onClick={handleDelete} disabled={isPending}>
+            {isPending ? '삭제 중...' : '삭제'}
+          </Modal.ConfirmButton>
         </Modal.Footer>
       </Modal>
     );

--- a/src/components/page-layout-ui/ListBookmarkOption.tsx
+++ b/src/components/page-layout-ui/ListBookmarkOption.tsx
@@ -15,20 +15,17 @@ interface ListBookmarkOptionInterface {
   initialTitle: string;
   initialLink?: string;
   type: string;
-  pageDescription?: string;
 }
 
 export default function ListBookMarkOption({
   isBookmark,
   setIsBookmark,
-  item,
   itemId,
   initialTitle,
   initialLink,
-  pageDescription,
+  type,
 }: ListBookmarkOptionInterface) {
   const [isDropDownInline, setIsDropDownInline] = useState(false);
-  const isDirectory = item.linkUrl ? 'link' : 'directory';
 
   const handleBookmark = () => {
     setIsBookmark((prev) => !prev);
@@ -60,13 +57,12 @@ export default function ListBookMarkOption({
       {isDropDownInline && (
         <DropDownInline
           id={itemId}
-          type={isDirectory}
+          type={type}
           initialTitle={initialTitle}
           initialLink={initialLink ?? ''}
           className="absolute top-10 right-1 z-1"
           isDropDownInline={isDropDownInline}
           setIsDropDownInline={setIsDropDownInline}
-          pageDescription={pageDescription ?? ''}
         />
       )}
     </div>

--- a/src/components/page-layout-ui/PageControllerSection.tsx
+++ b/src/components/page-layout-ui/PageControllerSection.tsx
@@ -10,8 +10,6 @@ import AddFolderModal from '../modal/folder/AddFolderModal';
 import AddLinkModal from '../modal/link/AddLinkModal';
 import { useCreateLink } from '@/hooks/mutations/useCreateLink';
 import { usePageStore, useParentsFolderIdStore } from '@/stores/pageStore';
-import { useDeleteLink } from '@/hooks/mutations/useDeleteLink';
-import { useLinkActionStore } from '@/stores/linkActionStore';
 import { useModalStore } from '@/stores/modalStore';
 import { useTransferFolder } from '@/hooks/mutations/useTransferFolder';
 import { useTransferActionStore } from '@/stores/transferActionStore';
@@ -31,30 +29,12 @@ export default function PageControllerSection({
     closeFolderModal,
   } = useModalStore();
   const pageId = usePageStore((state) => state.pageId);
-  const setDeleteLink = useLinkActionStore((state) => state.setDeleteLink);
   const setTransferFolder = useTransferActionStore(
     (state) => state.setTransferFolder
   );
   const { parentsFolderId } = useParentsFolderIdStore();
 
   const { mutate: createLink } = useCreateLink();
-
-  const { mutate: deleteLinkMutate } = useDeleteLink();
-  const deleteHandler = useCallback(
-    (id: number) => {
-      deleteLinkMutate({
-        baseRequest: {
-          pageId,
-          commandType: 'EDIT',
-        },
-        linkId: id,
-      });
-    },
-    [deleteLinkMutate, pageId]
-  );
-  useEffect(() => {
-    setDeleteLink(deleteHandler);
-  }, [setDeleteLink, deleteHandler]);
 
   const { mutate: transferFolder } = useTransferFolder();
   const transferHandler = useCallback(

--- a/src/hooks/useClickOutsideMultiple.ts
+++ b/src/hooks/useClickOutsideMultiple.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+
+export function useClickOutsideMultiple(
+  refs: React.RefObject<HTMLElement>[],
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>,
+  enabled: boolean = true
+) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+
+      const validRefs = refs.filter((ref) => ref.current !== null);
+      if (validRefs.length === 0) return;
+
+      let matchFound = false;
+
+      for (const ref of validRefs) {
+        if (ref.current!.contains(target)) {
+          matchFound = true;
+          break;
+        }
+      }
+
+      if (!matchFound) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [refs, setIsOpen, enabled]);
+}

--- a/src/hooks/useClickOutsideMultiple.ts
+++ b/src/hooks/useClickOutsideMultiple.ts
@@ -9,19 +9,18 @@ export function useClickOutsideMultiple(
     if (!enabled) return;
 
     const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Node;
+      const target = event.target as Node | null;
+      if (!target) return;
 
       const validRefs = refs.filter((ref) => ref.current !== null);
       if (validRefs.length === 0) return;
 
       let matchFound = false;
-
-      for (const ref of validRefs) {
+      validRefs.forEach((ref) => {
         if (ref.current!.contains(target)) {
           matchFound = true;
-          break;
         }
-      }
+      });
 
       if (!matchFound) {
         setIsOpen(false);


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- useClickOutsideMultiple 훅을 새로 작성하여 외부 클릭 감지 기능 모듈화
- DropDownInline 관련 모달들과 함께 외부 클릭 시 닫힘 처리되도록 적용
- ListBookmarkOption에서 DropDownInline에 전달되는 props 단순화
  - pageDescription, item 제거
  - type, title, link 등 명시적 전달 방식으로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 여러 모달이 동시에 열려 있을 때 바깥 클릭 시 드롭다운을 닫을 수 있도록 개선되었습니다.

- **버그 수정**
  - 폴더 및 링크 삭제 시 각각 별도 모달이 열리도록 분리되었습니다.

- **리팩터**
  - 삭제 모달과 관련된 상태 및 핸들러가 분리되어 관리가 더 명확해졌습니다.
  - Modal 컴포넌트가 ref를 지원하도록 개선되었습니다.
  - 삭제 모달들이 ref 전달 방식을 적용하여 일관성 있게 동작합니다.
  - 링크 삭제 로직이 모달 내에서 관리되도록 변경되었습니다.
  - 페이지 컨트롤러에서 링크 삭제 관련 코드가 제거되었습니다.
  - 북마크 옵션 컴포넌트의 타입 및 props 사용 방식이 개선되었습니다.

- **기타**
  - 불필요한 콘솔 로그 및 사용되지 않는 import가 제거되었습니다.
  - 여러 요소에 대한 바깥 클릭 감지를 위한 새로운 훅이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->