### PR TITLE
feat: 프로필 색상 변경 기능 구현 및 관련 훅/스토어 연동

### DIFF
--- a/src/apis/profile-apis/patchProfileColor.ts
+++ b/src/apis/profile-apis/patchProfileColor.ts
@@ -9,12 +9,8 @@ interface PatchProfileColorResponse {
 export const patchProfileColor = async (
   colorCode: string
 ): Promise<PatchProfileColorResponse> => {
-  try {
-    const response = await axiosInstance.patch('/api/member/color-code', {
-      colorCode,
-    });
-    return response.data;
-  } catch (error) {
-    throw error;
-  }
+  const response = await axiosInstance.patch('/api/member/color-code', {
+    colorCode,
+  });
+  return response.data;
 };

--- a/src/apis/profile-apis/patchProfileColor.ts
+++ b/src/apis/profile-apis/patchProfileColor.ts
@@ -1,0 +1,20 @@
+import { axiosInstance } from '../axiosInstance';
+
+interface PatchProfileColorResponse {
+  success: boolean;
+  colorCode: string;
+  message?: string;
+}
+
+export const patchProfileColor = async (
+  colorCode: string
+): Promise<PatchProfileColorResponse> => {
+  try {
+    const response = await axiosInstance.patch('/api/member/color-code', {
+      colorCode,
+    });
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/components/modal/profile/ProfileChangeBody.tsx
+++ b/src/components/modal/profile/ProfileChangeBody.tsx
@@ -3,10 +3,28 @@ import { useUserStore } from '@/stores/userStore';
 import { useState } from 'react';
 import ChevronLeft from '@/assets/common-ui-assets/ChevronLeft.svg?react';
 import Check from '@/assets/common-ui-assets/Check.svg?react';
+import { useUpdateProfileColor } from '@/hooks/mutations/useUpdateProfileColor';
+import { ToastCustom } from '@/components/common-ui/ToastCustom';
 
 const ProfileChangeBody = ({ onBack }: { onBack: () => void }) => {
   const { nickname, colorCode } = useUserStore();
   const [profileColor, setProfileColor] = useState(colorCode || '');
+  const hasChanges = profileColor !== colorCode;
+
+  const { mutate: updateColor, isPending } = useUpdateProfileColor();
+
+  const handleSaveAndBack = () => {
+    if (profileColor !== colorCode) {
+      updateColor(profileColor, {
+        onSuccess: () => {
+          ToastCustom.success('프로필 색상이 변경되었습니다.');
+          onBack();
+        },
+      });
+    } else {
+      onBack();
+    }
+  };
 
   const colorPalette = [
     '#FF6464',
@@ -26,10 +44,15 @@ const ProfileChangeBody = ({ onBack }: { onBack: () => void }) => {
       <Modal.Header>
         <div className="relative text-center">
           <button
-            className="absolute top-1/2 left-0 -translate-y-1/2 pl-1 text-lg hover:cursor-pointer"
-            onClick={onBack}
+            disabled={isPending}
+            className={`absolute top-1/2 left-0 flex -translate-y-1/2 items-center pl-1 text-lg hover:cursor-pointer ${
+              isPending ? 'cursor-not-allowed opacity-50' : ''
+            }`}
+            onClick={handleSaveAndBack}
+            aria-label="변경사항 저장하고 닫기"
           >
             <ChevronLeft />
+            {hasChanges ? '저장' : '완료'}
           </button>
           <h1 className="text-[22px] font-bold">프로필 변경</h1>
         </div>
@@ -46,7 +69,10 @@ const ProfileChangeBody = ({ onBack }: { onBack: () => void }) => {
             {colorPalette.map((color) => (
               <button
                 key={color}
-                className="relative h-[55px] w-[55px] rounded-full"
+                disabled={isPending}
+                className={`relative h-[55px] w-[55px] rounded-full ${
+                  isPending ? 'cursor-not-allowed opacity-50' : ''
+                }`}
                 style={{ backgroundColor: color }}
                 onClick={() => setProfileColor(color)}
                 type="button"

--- a/src/hooks/mutations/useUpdateProfileColor.ts
+++ b/src/hooks/mutations/useUpdateProfileColor.ts
@@ -1,0 +1,19 @@
+import { patchProfileColor } from '@/apis/profile-apis/patchProfileColor';
+import { ToastCustom } from '@/components/common-ui/ToastCustom';
+import { useUserStore } from '@/stores/userStore';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useUpdateProfileColor = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: patchProfileColor,
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['profileColor'] });
+      useUserStore.getState().setColorCode(variables);
+    },
+    onError: () => {
+      ToastCustom.error('색상 변경에 실패했습니다. 다시 시도해 주세요.');
+    },
+  });
+};

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -6,6 +6,7 @@ interface UserState {
   email: string;
   colorCode: string;
   setUser: (nickname: string, email: string, colorCode: string) => void;
+  setColorCode: (colorCode: string) => void;
   clearUser: () => void;
   isLoggedIn: boolean;
 }
@@ -19,6 +20,7 @@ export const useUserStore = create(
       isLoggedIn: false,
       setUser: (nickname: string, email: string, colorCode: string) =>
         set({ nickname, email, colorCode, isLoggedIn: true }),
+      setColorCode: (colorCode: string) => set({ colorCode }),
       clearUser: () =>
         set({ nickname: '', email: '', colorCode: '', isLoggedIn: false }),
     }),


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

### #️⃣ 118

> close #118 

## 📋 작업 내용

- PATCH /api/member/color-code API 연동
- useUpdateProfileColor 훅 작성 (React Query mutation)
- ProfileChangeBody 컴포넌트에서 색상 선택 및 변경 처리 추가
- userStore에서 colorCode 초기화 처리 보완

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 프로필 색상 변경 기능이 추가되어, 사용자가 프로필 색상을 선택하고 저장할 수 있습니다.
  - 색상 변경 시 성공/실패 알림이 표시됩니다.
- **사용성 개선**
  - 색상 변경 중에는 버튼이 비활성화되어 중복 입력을 방지합니다.
  - 접근성을 위한 버튼 속성이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->