### PR TITLE
feat: 닉네임 변경 기능 추가 및 프로필 api 응답 파싱 개선

### DIFF
--- a/src/apis/profile-apis/patchProfileColor.ts
+++ b/src/apis/profile-apis/patchProfileColor.ts
@@ -16,5 +16,8 @@ export const patchProfileColor = async (
     colorCode,
   });
 
+  if (response.data.status !== 200)
+    throw new Error(response.data.message ?? '프로필 색상 변경 실패');
+
   return response.data.data;
 };

--- a/src/apis/profile-apis/patchProfileColor.ts
+++ b/src/apis/profile-apis/patchProfileColor.ts
@@ -8,16 +8,8 @@ interface PatchProfileColorResponse {
 export const patchProfileColor = async (
   colorCode: string
 ): Promise<PatchProfileColorResponse> => {
-  const response = await axiosInstance.patch<{
-    status: number;
-    message: string;
-    data: PatchProfileColorResponse;
-  }>('/api/member/color-code', {
+  const { data } = await axiosInstance.patch('/api/member/color-code', {
     colorCode,
   });
-
-  if (response.data.status !== 200)
-    throw new Error(response.data.message ?? '프로필 색상 변경 실패');
-
-  return response.data.data;
+  return data.data;
 };

--- a/src/apis/profile-apis/patchProfileColor.ts
+++ b/src/apis/profile-apis/patchProfileColor.ts
@@ -1,16 +1,20 @@
 import { axiosInstance } from '../axiosInstance';
 
 interface PatchProfileColorResponse {
-  success: boolean;
+  email: string;
   colorCode: string;
-  message?: string;
 }
 
 export const patchProfileColor = async (
   colorCode: string
 ): Promise<PatchProfileColorResponse> => {
-  const response = await axiosInstance.patch('/api/member/color-code', {
+  const response = await axiosInstance.patch<{
+    status: number;
+    message: string;
+    data: PatchProfileColorResponse;
+  }>('/api/member/color-code', {
     colorCode,
   });
-  return response.data;
+
+  return response.data.data;
 };

--- a/src/apis/profile-apis/patchProfileNickname.ts
+++ b/src/apis/profile-apis/patchProfileNickname.ts
@@ -15,5 +15,8 @@ export const patchProfileNickname = async (
   }>('/api/member/nickname', {
     nickname,
   });
+
+  if (response.data.status !== 200) throw new Error(response.data.message);
+
   return response.data.data;
 };

--- a/src/apis/profile-apis/patchProfileNickname.ts
+++ b/src/apis/profile-apis/patchProfileNickname.ts
@@ -8,15 +8,8 @@ interface PatchProfileNicknameResponse {
 export const patchProfileNickname = async (
   nickname: string
 ): Promise<PatchProfileNicknameResponse> => {
-  const response = await axiosInstance.patch<{
-    status: number;
-    message: string;
-    data: PatchProfileNicknameResponse;
-  }>('/api/member/nickname', {
+  const { data } = await axiosInstance.patch('/api/member/nickname', {
     nickname,
   });
-
-  if (response.data.status !== 200) throw new Error(response.data.message);
-
-  return response.data.data;
+  return data.data;
 };

--- a/src/apis/profile-apis/patchProfileNickname.ts
+++ b/src/apis/profile-apis/patchProfileNickname.ts
@@ -1,0 +1,19 @@
+import { axiosInstance } from '../axiosInstance';
+
+interface PatchProfileNicknameResponse {
+  email: string;
+  nickname: string;
+}
+
+export const patchProfileNickname = async (
+  nickname: string
+): Promise<PatchProfileNicknameResponse> => {
+  const response = await axiosInstance.patch<{
+    status: number;
+    message: string;
+    data: PatchProfileNicknameResponse;
+  }>('/api/member/nickname', {
+    nickname,
+  });
+  return response.data.data;
+};

--- a/src/components/common-ui/Modal.tsx
+++ b/src/components/common-ui/Modal.tsx
@@ -67,7 +67,7 @@ const BaseModal = forwardRef<
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
         <div
           className={cn(
-            'flex w-full max-w-[70%] flex-col overflow-hidden rounded-2xl bg-white p-[24px] md:max-w-[466px]',
+            'flex w-full max-w-[70%] flex-col overflow-hidden rounded-2xl bg-white p-[24px] md:max-w-[530px]',
             className
           )}
           ref={modalRef}

--- a/src/components/modal/profile/ProfileChangeBody.tsx
+++ b/src/components/modal/profile/ProfileChangeBody.tsx
@@ -21,6 +21,13 @@ const ProfileChangeBody = ({ onBack }: { onBack: () => void }) => {
           ToastCustom.success('프로필 색상이 변경되었습니다.');
           onBack();
         },
+        onError: (error) => {
+          if (error instanceof Error) {
+            ToastCustom.error(error.message);
+          } else {
+            ToastCustom.error('알 수 없는 오류가 발생했습니다.');
+          }
+        },
       });
     } else {
       onBack();

--- a/src/components/modal/profile/ProfileSettingsModal.tsx
+++ b/src/components/modal/profile/ProfileSettingsModal.tsx
@@ -18,18 +18,22 @@ export const ProfileSettingsModal = ({
   onClose: () => void;
 }) => {
   const { nickname, email, colorCode } = useUserStore();
-  const [inputValue, setInputValue] = useState(nickname || '');
-  const [isEditingProfile, setIsEditingProfile] = useState(false);
 
   const { mutate: logout } = useLogoutMutation();
-  const { mutate: patchNickname } = useUpdateProfileNickname();
-
+  const { mutate: patchNickname, isPending } = useUpdateProfileNickname();
   const { isWithdrawModalOpen, openWithdrawModal, closeWithdrawModal } =
     useProfileModalStore();
+
+  const [inputValue, setInputValue] = useState(nickname || '');
+  const [isEditingProfile, setIsEditingProfile] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value);
   };
+
+  const trimmedInput = inputValue.trim();
+  const isNicknameInvalid = trimmedInput === '' || trimmedInput.length > 20;
+  const isNicknameUnchanged = trimmedInput === nickname.trim();
 
   const profileActions = [
     {
@@ -72,25 +76,34 @@ export const ProfileSettingsModal = ({
                 </button>
               </div>
               <div className="flex w-full flex-col">
-                <div className="flex items-center justify-between">
+                <div className="flex flex-wrap items-center justify-between gap-2">
                   <Input
-                    className="w-[295px]"
+                    className="xlg:w-full w-[295px] min-w-0 flex-1"
                     placeholder="닉네임을 입력해 주세요"
                     value={inputValue}
                     onChange={handleChange}
-                    // variant={error && !pageName ? 'error' : 'default'}
+                    variant={isNicknameInvalid ? 'error' : 'default'}
                     isModal
                   />
                   <Button
+                    className="whitespace-nowrap"
                     disabled={
-                      inputValue.trim() === nickname.trim() ||
-                      inputValue.trim() === ''
+                      isPending || isNicknameInvalid || isNicknameUnchanged
                     }
-                    onClick={() => patchNickname(inputValue)}
+                    onClick={() => {
+                      const trimmed = inputValue.trim();
+                      if (trimmed === '' || trimmed.length > 20) return;
+                      patchNickname(trimmed);
+                    }}
                   >
-                    닉네임 수정
+                    {isPending ? '수정 중...' : '닉네임 수정'}
                   </Button>
                 </div>
+                {isNicknameInvalid && (
+                  <p className="text-status-danger mt-1 text-sm">
+                    닉네임은 1자 이상 20자 이하로 입력해주세요.
+                  </p>
+                )}
                 <p className="text-[16px] font-[400] text-gray-50">{email}</p>
               </div>
             </div>

--- a/src/components/modal/profile/ProfileSettingsModal.tsx
+++ b/src/components/modal/profile/ProfileSettingsModal.tsx
@@ -7,6 +7,8 @@ import { useProfileModalStore } from '@/stores/profileModalStore';
 import WithdrawAccountModal from './WithdrawAccountModal';
 import ProfileChangeBody from './ProfileChangeBody';
 import { useLogoutMutation } from '@/hooks/mutations/auth/useLogoutMutation';
+import { Button } from '@/components/common-ui/button';
+import { useUpdateProfileNickname } from '@/hooks/mutations/useUpdateProfileNickname';
 
 export const ProfileSettingsModal = ({
   isOpen,
@@ -20,6 +22,7 @@ export const ProfileSettingsModal = ({
   const [isEditingProfile, setIsEditingProfile] = useState(false);
 
   const { mutate: logout } = useLogoutMutation();
+  const { mutate: patchNickname } = useUpdateProfileNickname();
 
   const { isWithdrawModalOpen, openWithdrawModal, closeWithdrawModal } =
     useProfileModalStore();
@@ -62,21 +65,32 @@ export const ProfileSettingsModal = ({
                   {nickname.charAt(0).toUpperCase()}
                 </div>
                 <button
-                  className="hover:cursor-pointer"
+                  className="text-gray-50 hover:cursor-pointer"
                   onClick={() => setIsEditingProfile(true)}
                 >
                   변경
                 </button>
               </div>
-              <div>
-                <Input
-                  className="w-[295px]"
-                  placeholder="닉네임을 입력해 주세요"
-                  value={inputValue}
-                  onChange={handleChange}
-                  // variant={error && !pageName ? 'error' : 'default'}
-                  isModal
-                />
+              <div className="flex w-full flex-col">
+                <div className="flex items-center justify-between">
+                  <Input
+                    className="w-[295px]"
+                    placeholder="닉네임을 입력해 주세요"
+                    value={inputValue}
+                    onChange={handleChange}
+                    // variant={error && !pageName ? 'error' : 'default'}
+                    isModal
+                  />
+                  <Button
+                    disabled={
+                      inputValue.trim() === nickname.trim() ||
+                      inputValue.trim() === ''
+                    }
+                    onClick={() => patchNickname(inputValue)}
+                  >
+                    닉네임 수정
+                  </Button>
+                </div>
                 <p className="text-[16px] font-[400] text-gray-50">{email}</p>
               </div>
             </div>

--- a/src/hooks/mutations/useUpdateProfileColor.ts
+++ b/src/hooks/mutations/useUpdateProfileColor.ts
@@ -9,7 +9,7 @@ export const useUpdateProfileColor = () => {
   return useMutation({
     mutationFn: patchProfileColor,
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['profileColor'] });
+      queryClient.invalidateQueries({ queryKey: ['personalPage'] });
       useUserStore.getState().setColorCode(variables);
     },
     onError: () => {

--- a/src/hooks/mutations/useUpdateProfileNickname.ts
+++ b/src/hooks/mutations/useUpdateProfileNickname.ts
@@ -8,12 +8,15 @@ export const useUpdateProfileNickname = () => {
 
   return useMutation({
     mutationFn: patchProfileNickname,
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['profileNickname'] });
-      useUserStore.getState().setNickname(variables);
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['personalPage'] });
+      useUserStore.getState().setNickname(data.nickname);
+      ToastCustom.success('닉네임을 변경했습니다.');
     },
-    onError: () => {
-      ToastCustom.error('닉네임 변경에 실패했습니다. 다시 시도해 주세요.');
+    onError: (error) => {
+      if (error instanceof Error) {
+        ToastCustom.error(error.message);
+      }
     },
   });
 };

--- a/src/hooks/mutations/useUpdateProfileNickname.ts
+++ b/src/hooks/mutations/useUpdateProfileNickname.ts
@@ -1,0 +1,19 @@
+import { patchProfileNickname } from '@/apis/profile-apis/patchProfileNickname';
+import { ToastCustom } from '@/components/common-ui/ToastCustom';
+import { useUserStore } from '@/stores/userStore';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useUpdateProfileNickname = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: patchProfileNickname,
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['profileNickname'] });
+      useUserStore.getState().setNickname(variables);
+    },
+    onError: () => {
+      ToastCustom.error('닉네임 변경에 실패했습니다. 다시 시도해 주세요.');
+    },
+  });
+};

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -7,6 +7,7 @@ interface UserState {
   colorCode: string;
   setUser: (nickname: string, email: string, colorCode: string) => void;
   setColorCode: (colorCode: string) => void;
+  setNickname: (nickname: string) => void;
   clearUser: () => void;
   isLoggedIn: boolean;
 }
@@ -21,6 +22,7 @@ export const useUserStore = create(
       setUser: (nickname: string, email: string, colorCode: string) =>
         set({ nickname, email, colorCode, isLoggedIn: true }),
       setColorCode: (colorCode: string) => set({ colorCode }),
+      setNickname: (nickname: string) => set({ nickname }),
       clearUser: () =>
         set({ nickname: '', email: '', colorCode: '', isLoggedIn: false }),
     }),


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

### #️⃣ 이슈 번호

> close #129 

## 📋 작업 내용

- 닉네임 변경 API (patchProfileNickname.ts) 구현
- useUpdateProfileNickname 훅 추가
- ProfileSettingsModal에 닉네임 수정 UI 및 로직 적용
- patchProfileColor.ts 응답 구조에 맞게 리턴 방식 수정
- userStore에 닉네임 상태 반영 로직 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 프로필 설정 모달에서 닉네임을 변경할 수 있는 기능이 추가되었습니다.
  - 닉네임 변경 시, 입력란 옆에 버튼이 나타나며, 변경된 닉네임을 저장할 수 있습니다.
  - 닉네임 변경을 위한 API와 관련 뮤테이션 훅이 새로 도입되었습니다.

- **개선 사항**
  - 프로필 색상 변경 시 응답 구조가 개선되어 이메일 정보가 함께 제공됩니다.
  - 프로필 설정 모달의 닉네임 표시 스타일이 개선되었습니다.
  - 모달의 최대 너비가 중간 크기 화면에서 더 넓어졌습니다.
  - 프로필 색상 변경 시 오류 발생 시 사용자에게 알림이 표시됩니다.
  - 프로필 색상 변경과 닉네임 변경 후 관련 데이터가 자동으로 갱신됩니다.

- **버그 수정**
  - 닉네임 변경 실패 시 알림 메시지가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->