### PR TITLE
feat: patch 추가 및 스타일, 훅등 부분 변경

### DIFF
--- a/src/apis/page-apis/patchSharedPageInvitation.ts
+++ b/src/apis/page-apis/patchSharedPageInvitation.ts
@@ -1,0 +1,17 @@
+import { PatchSharedPageInvitationData } from '@/types/pages';
+import { axiosInstance } from '../axiosInstance';
+
+export default async function patchSharedPageInvitation(
+  data: PatchSharedPageInvitationData
+) {
+  try {
+    const response = await axiosInstance.patch(
+      '/api/dispatch/share-page-invitations/status',
+      data
+    );
+    return response.data;
+  } catch (error) {
+    console.error('Error patching shared page invitation:', error);
+    throw error;
+  }
+}

--- a/src/apis/page-apis/updateSharedPageInvitation.ts
+++ b/src/apis/page-apis/updateSharedPageInvitation.ts
@@ -6,7 +6,7 @@ export default async function updateSharedPageInvitation(
 ) {
   try {
     const response = await axiosInstance.post(
-      '/api/page/updateSharedPageInvitation',
+      '/api/dispatch/share-page-invitations',
       data
     );
     return response.data;

--- a/src/apis/page-apis/updateSharedPageMemberType.ts
+++ b/src/apis/page-apis/updateSharedPageMemberType.ts
@@ -1,0 +1,17 @@
+import { UpdateSharedPagePermissionData } from '@/types/pages';
+import { axiosInstance } from '../axiosInstance';
+
+export default async function updateSharedPageMemberTy(
+  data: UpdateSharedPagePermissionData
+) {
+  try {
+    const response = await axiosInstance.put(
+      '/api/share-pages/dashboard/members/permission',
+      data
+    );
+    return response.data;
+  } catch (error) {
+    console.error('Error updating shared page member type:', error);
+    throw error;
+  }
+}

--- a/src/components/common-ui/ModalOptions.tsx
+++ b/src/components/common-ui/ModalOptions.tsx
@@ -1,41 +1,38 @@
-import useUpdateSharedPageInvitation from '@/hooks/mutations/updateSharedPageInvitation';
+import { useUpdateSharedPageMemberType } from '@/hooks/mutations/useUpdateSharedPageMemberType';
+import { UpdateSharedPagePermissionData } from '@/types/pages';
 import { useState } from 'react';
 
 export default function ModalOptions({
   userRole,
   pageId,
   email,
+  memberId,
 }: {
   userRole: string;
   pageId: number;
   email: string;
+  memberId: number;
 }) {
   const [role, setRole] = useState(userRole || '');
 
-  const updateMemberRole = useUpdateSharedPageInvitation({
-    pageId,
-    onSuccess: () => {
-      console.log('역할 변경 성공toast적용');
-    },
-    onError: (error) => {
-      console.error('역할 변경 실패:', error);
-    },
-  });
+  const updateMemberRole = useUpdateSharedPageMemberType();
 
   const handleRoleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (!pageId) return;
 
-    updateMemberRole.mutate({
+    const requestBody: UpdateSharedPagePermissionData = {
       baseRequest: {
         pageId,
-        commandType: 'SHARED_PAGE_INVITATION',
+        commandType: 'SHARED_PAGE_PERMISSION_CHANGE',
       },
-      receiverEmail: email,
-      permissionType: e.target.value as 'VIEWER' | 'EDITOR' | 'HOST' | 'null',
-    });
+      targetMemberId: memberId,
+      permissionType: role,
+    };
 
+    updateMemberRole.mutate(requestBody);
     setRole(e.target.value as 'VIEWER' | 'EDITOR' | 'HOST' | 'null');
 
+    console.log('권한 변경 데이터', requestBody);
     console.log('권한변경', pageId, email, e.target.value);
   };
 

--- a/src/components/modal/folder/AddFolderModal.tsx
+++ b/src/components/modal/folder/AddFolderModal.tsx
@@ -45,7 +45,7 @@ export default function AddFolderModal({
     const requestBody = {
       baseRequest: {
         pageId,
-        commandType: 'EDIT',
+        commandType: 'CREATE',
       },
       folderName,
       parentFolderId: parentsFolderId ?? 1,

--- a/src/components/modal/page/InviteUserModal.tsx
+++ b/src/components/modal/page/InviteUserModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import Modal from '@/components/common-ui/Modal';
 import { Button } from '@/components/common-ui/button';
 import useUpdateSharedPageInvitation from '@/hooks/mutations/updateSharedPageInvitation';
+import { UpdateSharedPageInvitationData } from '@/types/pages';
 
 interface EmailInputWithRoleProps {
   email: string;
@@ -60,16 +61,19 @@ const InviteUserModal = ({ isOpen, onClose, pageId }: InviteUserModalProps) => {
   const handleInvite = () => {
     if (!email) return;
 
-    updateSharedPageInvitation.mutate({
+    const requestBody: UpdateSharedPageInvitationData = {
       baseRequest: {
         pageId,
         commandType: 'SHARED_PAGE_INVITATION',
       },
       receiverEmail: email,
       permissionType: role,
-    });
+    };
+
+    updateSharedPageInvitation.mutate(requestBody);
 
     setButtonStatus('완료');
+    console.log('초대 요청 데이터', requestBody);
     console.log('초대 완료');
     console.log(pageId, email, role);
   };

--- a/src/components/modal/page/ManageSharedPageModal.tsx
+++ b/src/components/modal/page/ManageSharedPageModal.tsx
@@ -181,13 +181,13 @@ const ManageSharedPageModal = ({
         </div>
 
         <div className="max-h-[220px] overflow-y-auto">
-          {filteredMembers.map((m, i) => (
+          {filteredMembers.map((m) => (
             <div
               key={m.memberId}
               className="border-gray-10 flex items-center gap-3 border-b py-2 last:border-b-0"
             >
               <div
-                className="text-primary-0 flex items-center justify-center rounded-full px-[16px] py-[10px] text-[22px] font-[500]"
+                className="text-primary-0 flex h-[40px] w-[40px] items-center justify-center rounded-full px-[16px] py-[10px] text-[22px] font-[500]"
                 style={{ backgroundColor: m.colorCode }}
               >
                 {m.nickName[0]}
@@ -204,9 +204,13 @@ const ManageSharedPageModal = ({
                     userRole={m.role}
                     pageId={resolvedPageId ?? -1}
                     email={m.email}
+                    memberId={m.memberId}
                   />
                 ) : (
-                  <Button variant="ghost" className="bg-gray-20 text-gray-50">
+                  <Button
+                    variant="ghost"
+                    className="bg-gray-20 h-[42px] w-[87px] text-[14px] text-gray-50"
+                  >
                     수락 대기
                   </Button>
                 )}

--- a/src/components/modal/page/WithdrawlSharedPageModal.tsx
+++ b/src/components/modal/page/WithdrawlSharedPageModal.tsx
@@ -34,6 +34,8 @@ const WithdrawSharedPageModal = forwardRef<
         console.error('공유 페이지 탈퇴 실패:', error);
       },
     });
+
+    console.log('공유 페이지 탈퇴 데이터', requestBody);
   };
 
   return (

--- a/src/components/side-bar/SideBar.tsx
+++ b/src/components/side-bar/SideBar.tsx
@@ -74,7 +74,7 @@ const SideBar: React.FC<MenubarProps> = ({ showSidebar, setShowSidebar }) => {
           >
             <div
               style={{ backgroundColor: colorCode }}
-              className="flex h-[50px] w-[50px] items-center justify-center rounded-full p-[8px]"
+              className="flex h-[50px] w-[50px] items-center justify-center rounded-full p-[8px] text-[22px]"
             >
               {nickname.charAt(0).toUpperCase()}
             </div>

--- a/src/hooks/mutations/useCreateFolder.ts
+++ b/src/hooks/mutations/useCreateFolder.ts
@@ -5,13 +5,15 @@ import {
 } from '@tanstack/react-query';
 import { createFolder } from '@/apis/folder-apis/createFolder';
 import { CreateFolderData } from '@/types/folders';
-
+import { useLocation } from 'react-router-dom';
 export function useCreateFolder(
   pageId: number,
   options?: UseMutationOptions<any, unknown, CreateFolderData>
 ) {
   const queryClient = useQueryClient();
-  const isMainPage = pageId === 1;
+  const location = useLocation();
+  const isMainPage = location.pathname === '/';
+
   return useMutation({
     ...options,
     mutationFn: createFolder,

--- a/src/hooks/mutations/usePatchSharedPageInvitations.ts
+++ b/src/hooks/mutations/usePatchSharedPageInvitations.ts
@@ -1,0 +1,16 @@
+import patchSharedPageInvitation from '@/apis/page-apis/patchSharedPageInvitation';
+import { useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
+
+export default function usePatchSharedPageInvitations() {
+  const queryClient = useQueryClient();
+
+  return useMutation<any, Error, any>({
+    mutationFn: patchSharedPageInvitation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['notification'],
+      });
+    },
+  });
+}

--- a/src/hooks/mutations/useUpdateSharedPageMemberType.ts
+++ b/src/hooks/mutations/useUpdateSharedPageMemberType.ts
@@ -1,0 +1,22 @@
+import updateSharedPageMemberType from '@/apis/page-apis/updateSharedPageMemberType';
+import { ToastCustom } from '@/components/common-ui/ToastCustom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useUpdateSharedPageMemberType = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateSharedPageMemberType,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: ['sharedPageDashboard', data.pageId],
+      });
+      ToastCustom.success('권한을 변경했습니다.');
+    },
+    onError: (error) => {
+      if (error instanceof Error) {
+        ToastCustom.error(error.message);
+      }
+    },
+  });
+};

--- a/src/types/pages.ts
+++ b/src/types/pages.ts
@@ -60,3 +60,18 @@ export interface UpdateSharedPageInvitationData {
   receiverEmail: string;
   permissionType: string;
 }
+
+export interface UpdateSharedPagePermissionData {
+  baseRequest: {
+    pageId: number;
+    commandType: 'SHARED_PAGE_PERMISSION_CHANGE';
+  };
+  targetMemberId: number;
+  permissionType: string;
+}
+
+export interface PatchSharedPageInvitationData {
+  requestId: number;
+  requestStatus: string;
+  notificationType: string;
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

### #️⃣ 이슈 번호

> close #135 

## 📋 작업 내용

- 초대기능 동작으로 인한 알람 patch 추가 (이후 알람 에러가 해결 된 후 추가설정예정)
- 사이드바 프로필 스타일 수정
- 공유페이지 관리 모달내 버튼 및 옵션 스타일 수정
- useCreateFolder 개인페이지 쿼리무효화 조건 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 공유 페이지 초대 상태 변경 및 멤버 권한 변경을 위한 기능이 추가되었습니다.
  - 폴더 생성 시 명령어가 'CREATE'로 수정되었습니다.

- **버그 수정**
  - 메인 페이지 판별 로직이 페이지 ID가 아닌 URL 경로로 변경되었습니다.

- **UI/스타일**
  - 사이드바에서 사용자 이니셜의 글자 크기가 22px로 커졌습니다.
  - 공유 페이지 관리 모달 내 버튼 및 아바타 크기가 일관성 있게 조정되었습니다.

- **기타**
  - 일부 요청에 타입 명시 및 콘솔 로그가 추가되어 데이터 확인이 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->